### PR TITLE
Correct Javadoc on DataSetProducer

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/dataset/DataSetProducer.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/dataset/DataSetProducer.java
@@ -37,7 +37,7 @@ public interface DataSetProducer {
 
   /**
    * Closes the data set once reading is complete. Implementations should expect to receive
-   * exactly one call to this method at the start of processing.
+   * exactly one call to this method at the end of processing.
    */
   public void close();
 


### PR DESCRIPTION
close() is called once at the end of processing.