### PR TITLE
Remove the dependency on H2 database from morf-core

### DIFF
--- a/morf-core/pom.xml
+++ b/morf-core/pom.xml
@@ -65,10 +65,6 @@
       <artifactId>guice-multibindings</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.h2database</groupId>
-      <artifactId>h2</artifactId>
-    </dependency>
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>

--- a/morf-h2/pom.xml
+++ b/morf-h2/pom.xml
@@ -42,5 +42,9 @@
       <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/morf-testsupport/pom.xml
+++ b/morf-testsupport/pom.xml
@@ -44,5 +44,9 @@
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.h2database</groupId>
+      <artifactId>h2</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
It's clearly wrong.

Added it to morf-h2 (makes sense) and had to add it to morf-testsupport for now, since that's where the H2DatabaseInspector is.

Code changes are almost entirely to remove references to a ResultSet class in H2 that we were using in a test.

Fixes #18 
