### PR TITLE
Equals, hashCode and optional immutability in AliasedField implementations (#7)

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -1476,9 +1476,6 @@ public abstract class SqlDialect {
    * @return a string representation of the field
    */
   protected String getSqlFrom(AliasedField field) {
-    if (field instanceof NullFieldLiteral) {
-      return "null";
-    }
 
     if (field instanceof SqlParameter) {
       return String.format(":%s", ((SqlParameter)field).getImpliedName());
@@ -1596,6 +1593,11 @@ public abstract class SqlDialect {
       case BLOB:
       case CLOB:
         return field.getValue();
+      case NULL:
+        if (field.getValue() != null) {
+          throw new UnsupportedOperationException("Literals of type NULL must have a null value. Got [" + field.getValue() + "]");
+        }
+        return "null";
       default:
         throw new UnsupportedOperationException("Cannot convert the specified field literal into an SQL literal: ["
             + field.getValue() + "]");

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/SqlUtils.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/SqlUtils.java
@@ -19,9 +19,8 @@ import static org.alfasoftware.morf.metadata.DataType.STRING;
 import static org.alfasoftware.morf.metadata.SchemaUtils.column;
 import static org.alfasoftware.morf.sql.element.Criterion.eq;
 
+import java.math.BigDecimal;
 import java.util.List;
-
-import org.joda.time.LocalDate;
 
 import org.alfasoftware.morf.metadata.Column;
 import org.alfasoftware.morf.metadata.DataType;
@@ -42,6 +41,7 @@ import org.alfasoftware.morf.sql.element.SqlParameter;
 import org.alfasoftware.morf.sql.element.TableReference;
 import org.alfasoftware.morf.sql.element.WhenCondition;
 import org.alfasoftware.morf.sql.element.WindowFunction;
+import org.joda.time.LocalDate;
 
 /**
  * Utility methods for creating SQL constructs.
@@ -212,6 +212,17 @@ public class SqlUtils {
    * @return {@link FieldLiteral}
    */
   public static FieldLiteral literal(String value) {
+    return new FieldLiteral(value);
+  }
+
+
+  /**
+   * Constructs a new {@link FieldLiteral} with a {@link BigDecimal} source.
+   *
+   * @param value the literal value to use
+   * @return {@link FieldLiteral}
+   */
+  public static FieldLiteral literal(BigDecimal value) {
     return new FieldLiteral(value);
   }
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/AliasedField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/AliasedField.java
@@ -138,7 +138,7 @@ public abstract class AliasedField implements AliasedFieldBuilder, DeepCopyableW
    * @param transformer the transformation to execute during the copy
    * @return deep copy of the field
    */
-  protected abstract AliasedField deepCopyInternal(DeepCopyTransformation transformer);
+  protected abstract AliasedFieldBuilder deepCopyInternal(DeepCopyTransformation transformer);
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/AliasedField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/AliasedField.java
@@ -21,6 +21,7 @@ import static org.alfasoftware.morf.util.DeepCopyTransformations.noTransformatio
 import java.util.List;
 
 import org.alfasoftware.morf.sql.SelectStatement;
+import org.alfasoftware.morf.sql.SqlUtils;
 import org.alfasoftware.morf.util.DeepCopyTransformation;
 import org.alfasoftware.morf.util.DeepCopyableWithTransformation;
 import org.apache.commons.lang.StringUtils;
@@ -170,7 +171,7 @@ public abstract class AliasedField implements AliasedFieldBuilder, DeepCopyableW
    * @return The value, negated, with the original implied name.
    */
   public AliasedField negated() {
-    return FieldLiteral.literal(0).minus(this).as(getImpliedName());
+    return SqlUtils.literal(0).minus(this).as(getImpliedName());
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/AliasedField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/AliasedField.java
@@ -71,7 +71,7 @@ public abstract class AliasedField implements AliasedFieldBuilder, DeepCopyableW
    */
   @Override
   public AliasedField as(String aliasName) {
-    if (refactoredForImmutability() && immutableDslEnabled()) {
+    if (immutableDslEnabled()) {
       return shallowCopy(aliasName);
     } else {
     this.alias = aliasName;
@@ -93,18 +93,6 @@ public abstract class AliasedField implements AliasedFieldBuilder, DeepCopyableW
   @Override
   public final AliasedField build() {
     return this;
-  }
-
-
-  /**
-   * Transitional flag which tells {@link #as(String)} and other similar
-   * pseudo-builder methods whether the implementation has been refactored
-   * to handle these in an immutable fashion.
-   *
-   * @return If the implementation has been refactored to behave immutably.
-   */
-  protected boolean refactoredForImmutability() {
-    return false;
   }
 
 
@@ -146,14 +134,7 @@ public abstract class AliasedField implements AliasedFieldBuilder, DeepCopyableW
    */
   @Override
   public AliasedFieldBuilder deepCopy(DeepCopyTransformation transformer) {
-    AliasedFieldBuilder builder =  deepCopyInternal(transformer);
-    if (refactoredForImmutability() || StringUtils.isBlank(this.alias)) {
-      return builder;
-    } else {
-      // TODO This should be unnecessary...
-      builder.as(this.alias);
-    }
-    return builder;
+    return deepCopyInternal(transformer);
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BracketedExpression.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BracketedExpression.java
@@ -33,10 +33,47 @@ public class BracketedExpression extends AliasedField implements Driver {
 
 
   /**
-   * @param innerExpression expression to be wrapped with a bracket.
+   * Method that wraps a first elements of an (sub)expression with a bracket.
+   * <p>
+   * For example, in order to generate "(a + b) / c" SQL Math expression, we
+   * need to put first two elements (first subexpression) into a bracket. That
+   * could be achieved by the following DSL statement.
+   * </p>
+   *
+   * <pre>
+   * bracket(field(&quot;a&quot;).plus(field(&quot;b&quot;))).divideBy(field(&quot;c&quot;))
+   * </pre>
+   *
+   *
+   * @param expression the input Math expression that will be wrapped with
+   *          brackets in output SQL
+   * @return new expression containing the input expression wrapped with
+   *         brackets
    */
+  public static BracketedExpression bracket(MathsField expression) {
+    return new BracketedExpression("", expression);
+  }
+
+
+  @Override
+  public BracketedExpression as(String aliasName) {
+    return (BracketedExpression) super.as(aliasName);
+  }
+
+
+  /**
+   * @param innerExpression expression to be wrapped with a bracket.
+   * @deprecated Use {@link #bracket(MathsField)}.
+   */
+  @Deprecated
   public BracketedExpression(MathsField innerExpression) {
     super();
+    this.innerExpression = innerExpression;
+  }
+
+
+  private BracketedExpression(final String alias, MathsField innerExpression) {
+    super(alias);
     this.innerExpression = innerExpression;
   }
 
@@ -50,29 +87,59 @@ public class BracketedExpression extends AliasedField implements Driver {
   }
 
 
-  /**
-   * @see org.alfasoftware.morf.sql.element.AliasedField#deepCopyInternal(DeepCopyTransformation)
-   */
   @Override
-  protected AliasedField deepCopyInternal(DeepCopyTransformation transformer) {
-    return new BracketedExpression((MathsField) transformer.deepCopy(innerExpression));
+  protected BracketedExpression deepCopyInternal(DeepCopyTransformation transformer) {
+    return new BracketedExpression(this.getAlias(), (MathsField) transformer.deepCopy(innerExpression));
   }
 
 
-  /**
-   * @see org.alfasoftware.morf.util.ObjectTreeTraverser.Driver#drive(ObjectTreeTraverser)
-   */
+  @Override
+  protected BracketedExpression shallowCopy(String aliasName) {
+    return new BracketedExpression(aliasName, innerExpression);
+  }
+
+
+  @Override
+  protected boolean refactoredForImmutability() {
+    return true;
+  }
+
+
   @Override
   public void drive(ObjectTreeTraverser traverser) {
     traverser.dispatch(getInnerExpression());
   }
 
 
-  /**
-   * @see java.lang.Object#toString()
-   */
   @Override
   public String toString() {
     return "(" + innerExpression + ")" + super.toString();
+  }
+
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((innerExpression == null) ? 0 : innerExpression.hashCode());
+    return result;
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (!super.equals(obj))
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    BracketedExpression other = (BracketedExpression) obj;
+    if (innerExpression == null) {
+      if (other.innerExpression != null)
+        return false;
+    } else if (!innerExpression.equals(other.innerExpression))
+      return false;
+    return true;
   }
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BracketedExpression.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BracketedExpression.java
@@ -63,9 +63,7 @@ public class BracketedExpression extends AliasedField implements Driver {
 
   /**
    * @param innerExpression expression to be wrapped with a bracket.
-   * @deprecated Use {@link #bracket(MathsField)}.
    */
-  @Deprecated
   public BracketedExpression(MathsField innerExpression) {
     super();
     this.innerExpression = innerExpression;

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BracketedExpression.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BracketedExpression.java
@@ -100,12 +100,6 @@ public class BracketedExpression extends AliasedField implements Driver {
 
 
   @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
-  @Override
   public void drive(ObjectTreeTraverser traverser) {
     traverser.dispatch(getInnerExpression());
   }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BracketedExpression.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BracketedExpression.java
@@ -32,29 +32,6 @@ public class BracketedExpression extends AliasedField implements Driver {
   private final MathsField innerExpression;
 
 
-  /**
-   * Method that wraps a first elements of an (sub)expression with a bracket.
-   * <p>
-   * For example, in order to generate "(a + b) / c" SQL Math expression, we
-   * need to put first two elements (first subexpression) into a bracket. That
-   * could be achieved by the following DSL statement.
-   * </p>
-   *
-   * <pre>
-   * bracket(field(&quot;a&quot;).plus(field(&quot;b&quot;))).divideBy(field(&quot;c&quot;))
-   * </pre>
-   *
-   *
-   * @param expression the input Math expression that will be wrapped with
-   *          brackets in output SQL
-   * @return new expression containing the input expression wrapped with
-   *         brackets
-   */
-  public static BracketedExpression bracket(MathsField expression) {
-    return new BracketedExpression("", expression);
-  }
-
-
   @Override
   public BracketedExpression as(String aliasName) {
     return (BracketedExpression) super.as(aliasName);

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/CaseStatement.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/CaseStatement.java
@@ -88,12 +88,6 @@ public class CaseStatement extends AliasedField implements Driver {
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * @return the whenConditions
    */

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Cast.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Cast.java
@@ -104,12 +104,6 @@ public class Cast extends AliasedField implements Driver {
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * @return The {@link AliasedField} being casted
    */

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Cast.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Cast.java
@@ -16,6 +16,7 @@
 package org.alfasoftware.morf.sql.element;
 
 import org.alfasoftware.morf.metadata.DataType;
+import org.alfasoftware.morf.sql.SqlUtils;
 import org.alfasoftware.morf.util.DeepCopyTransformation;
 import org.alfasoftware.morf.util.ObjectTreeTraverser;
 import org.alfasoftware.morf.util.ObjectTreeTraverser.Driver;
@@ -45,7 +46,7 @@ public class Cast extends AliasedField implements Driver {
   /**
    * The data type to cast to.
    */
-  private final DataType       dataType;
+  private final DataType dataType;
 
 
   /**
@@ -55,9 +56,20 @@ public class Cast extends AliasedField implements Driver {
    * @param dataType the data type to cast to.
    * @param width the width.
    * @param scale the scale.
+   * @deprecated Use {@link SqlUtils#cast(AliasedField)}.
    */
+  @Deprecated
   public Cast(AliasedField expression, DataType dataType, int width, int scale) {
     super();
+    this.expression = expression;
+    this.dataType = dataType;
+    this.width = width;
+    this.scale = scale;
+  }
+
+
+  private Cast(String alias, AliasedField expression, DataType dataType, int width, int scale) {
+    super(alias);
     this.expression = expression;
     this.dataType = dataType;
     this.width = width;
@@ -82,7 +94,19 @@ public class Cast extends AliasedField implements Driver {
    */
   @Override
   protected AliasedField deepCopyInternal(DeepCopyTransformation transformer) {
-    return new Cast(transformer.deepCopy(expression), dataType, width, scale);
+    return new Cast(getAlias(), transformer.deepCopy(expression), dataType, width, scale);
+  }
+
+
+  @Override
+  protected AliasedField shallowCopy(String aliasName) {
+    return new Cast(aliasName, expression, dataType, width, scale);
+  }
+
+
+  @Override
+  protected boolean refactoredForImmutability() {
+    return true;
   }
 
 
@@ -123,9 +147,7 @@ public class Cast extends AliasedField implements Driver {
    */
   @Override
   public Cast as(String aliasName) {
-    super.as(aliasName);
-
-    return this;
+    return (Cast) super.as(aliasName);
   }
 
 
@@ -144,5 +166,41 @@ public class Cast extends AliasedField implements Driver {
   @Override
   public String toString() {
     return String.format("CAST(%s AS %s(%s, %s))%s", expression, dataType, width, scale, super.toString());
+  }
+
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((dataType == null) ? 0 : dataType.hashCode());
+    result = prime * result + ((expression == null) ? 0 : expression.hashCode());
+    result = prime * result + scale;
+    result = prime * result + width;
+    return result;
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (!super.equals(obj))
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    Cast other = (Cast) obj;
+    if (dataType != other.dataType)
+      return false;
+    if (expression == null) {
+      if (other.expression != null)
+        return false;
+    } else if (!expression.equals(other.expression))
+      return false;
+    if (scale != other.scale)
+      return false;
+    if (width != other.width)
+      return false;
+    return true;
   }
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Cast.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Cast.java
@@ -16,7 +16,6 @@
 package org.alfasoftware.morf.sql.element;
 
 import org.alfasoftware.morf.metadata.DataType;
-import org.alfasoftware.morf.sql.SqlUtils;
 import org.alfasoftware.morf.util.DeepCopyTransformation;
 import org.alfasoftware.morf.util.ObjectTreeTraverser;
 import org.alfasoftware.morf.util.ObjectTreeTraverser.Driver;
@@ -56,9 +55,7 @@ public class Cast extends AliasedField implements Driver {
    * @param dataType the data type to cast to.
    * @param width the width.
    * @param scale the scale.
-   * @deprecated Use {@link SqlUtils#cast(AliasedField)}.
    */
-  @Deprecated
   public Cast(AliasedField expression, DataType dataType, int width, int scale) {
     super();
     this.expression = expression;

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/ConcatenatedField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/ConcatenatedField.java
@@ -40,23 +40,10 @@ public class ConcatenatedField extends AliasedField implements Driver {
 
 
   /**
-   * Returns an expression concatenating all the passed expressions.
-   *
-   * @param fields the expressions to concatenate.
-   * @return the expression concatenating the passed expressions.
-   */
-  public static ConcatenatedField concat(AliasedField... fields) {
-    return new ConcatenatedField(fields);
-  }
-
-
-  /**
    * Constructs a ConcatenatedField.
    *
    * @param fields the fields to be concatenated
-   * @deprecated Use {@link #concat(AliasedField...)}
    */
-  @Deprecated
   public ConcatenatedField(AliasedField... fields) {
     super();
     // We need at least two fields to concatenate

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/ConcatenatedField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/ConcatenatedField.java
@@ -88,12 +88,6 @@ public class ConcatenatedField extends AliasedField implements Driver {
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * Get the fields to be concatenated
    *

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldFromSelect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldFromSelect.java
@@ -78,12 +78,6 @@ public class FieldFromSelect extends AliasedField implements Driver{
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * @see org.alfasoftware.morf.util.ObjectTreeTraverser.Driver#drive(ObjectTreeTraverser)
    */

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldFromSelect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldFromSelect.java
@@ -33,19 +33,9 @@ public class FieldFromSelect extends AliasedField implements Driver{
   private final SelectStatement selectStatement;
 
 
-  /**
-   * Constructor used to create the deep copy of this field from select
-   *
-   * @param sourceField the field from select to copy from
-   */
-  private FieldFromSelect(FieldFromSelect sourceField,DeepCopyTransformation transformer) {
-    super();
-
-    if (sourceField.getAlias() != null) {
-      this.as(sourceField.getAlias());
-    }
-
-    this.selectStatement = transformer.deepCopy(sourceField.selectStatement);
+  private FieldFromSelect(String alias, SelectStatement selectStatement) {
+    super(alias == null ? "" : alias);
+    this.selectStatement = selectStatement;
   }
 
   /**
@@ -78,7 +68,19 @@ public class FieldFromSelect extends AliasedField implements Driver{
    */
   @Override
   protected AliasedField deepCopyInternal(DeepCopyTransformation transformer) {
-    return new FieldFromSelect(this,transformer);
+    return new FieldFromSelect(getAlias(), transformer.deepCopy(selectStatement));
+  }
+
+
+  @Override
+  protected AliasedField shallowCopy(String aliasName) {
+    return new FieldFromSelect(aliasName, selectStatement);
+  }
+
+
+  @Override
+  protected boolean refactoredForImmutability() {
+    return true;
   }
 
 
@@ -97,5 +99,32 @@ public class FieldFromSelect extends AliasedField implements Driver{
   @Override
   public String toString() {
     return selectStatement.toString() + super.toString();
+  }
+
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((selectStatement == null) ? 0 : selectStatement.hashCode());
+    return result;
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (!super.equals(obj))
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    FieldFromSelect other = (FieldFromSelect) obj;
+    if (selectStatement == null) {
+      if (other.selectStatement != null)
+        return false;
+    } else if (!selectStatement.equals(other.selectStatement))
+      return false;
+    return true;
   }
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldFromSelectFirst.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldFromSelectFirst.java
@@ -74,12 +74,6 @@ public class FieldFromSelectFirst extends AliasedField implements Driver {
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * @see org.alfasoftware.morf.util.ObjectTreeTraverser.Driver#drive(ObjectTreeTraverser)
    */

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldFromSelectFirst.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldFromSelectFirst.java
@@ -33,21 +33,11 @@ public class FieldFromSelectFirst extends AliasedField implements Driver {
   private final SelectFirstStatement selectFirstStatement;
 
 
-  /**
-   * Constructor used to create the deep copy of this field from select
-   *
-   * @param sourceField the field from select to copy from
-   * @param transformer The transformation to execute during the copy
-   */
-  private FieldFromSelectFirst(FieldFromSelectFirst sourceField,DeepCopyTransformation transformer) {
-    super();
-
-    if (sourceField.getAlias() != null) {
-      this.as(sourceField.getAlias());
-    }
-
-    this.selectFirstStatement = transformer.deepCopy(sourceField.selectFirstStatement);
+  private FieldFromSelectFirst(String alias, SelectFirstStatement selectFirstStatement) {
+    super(alias == null ? "" : alias);
+    this.selectFirstStatement = selectFirstStatement;
   }
+
 
   /**
    * Constructor to create a field from a {@link SelectFirstStatement}
@@ -57,7 +47,6 @@ public class FieldFromSelectFirst extends AliasedField implements Driver {
    */
   public FieldFromSelectFirst(SelectFirstStatement selectStatement) {
     super();
-
     this.selectFirstStatement = selectStatement;
   }
 
@@ -75,7 +64,19 @@ public class FieldFromSelectFirst extends AliasedField implements Driver {
    */
   @Override
   protected AliasedField deepCopyInternal(DeepCopyTransformation transformer) {
-    return new FieldFromSelectFirst(this,transformer);
+    return new FieldFromSelectFirst(getAlias(), transformer.deepCopy(selectFirstStatement));
+  }
+
+
+  @Override
+  protected AliasedField shallowCopy(String aliasName) {
+    return new FieldFromSelectFirst(aliasName, selectFirstStatement);
+  }
+
+
+  @Override
+  protected boolean refactoredForImmutability() {
+    return true;
   }
 
 
@@ -94,5 +95,32 @@ public class FieldFromSelectFirst extends AliasedField implements Driver {
   @Override
   public String toString() {
     return selectFirstStatement.toString() + super.toString();
+  }
+
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((selectFirstStatement == null) ? 0 : selectFirstStatement.hashCode());
+    return result;
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (!super.equals(obj))
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    FieldFromSelectFirst other = (FieldFromSelectFirst) obj;
+    if (selectFirstStatement == null) {
+      if (other.selectFirstStatement != null)
+        return false;
+    } else if (!selectFirstStatement.equals(other.selectFirstStatement))
+      return false;
+    return true;
   }
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldLiteral.java
@@ -20,6 +20,8 @@ import java.math.BigDecimal;
 import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.sql.Statement;
 import org.alfasoftware.morf.util.DeepCopyTransformation;
+import org.apache.commons.lang.builder.EqualsBuilder;
+import org.apache.commons.lang.builder.HashCodeBuilder;
 import org.joda.time.LocalDate;
 
 
@@ -42,15 +44,115 @@ public class FieldLiteral extends AliasedField {
 
 
   /**
-   * Constructor used to create the deep copy of this field literal
-   *
-   * @param sourceField the field literal to create the copy from
+   * @return A literal representing NULL.
    */
-  private FieldLiteral(FieldLiteral sourceField) {
-    super();
+  public static FieldLiteral nullLiteral() {
+    return new FieldLiteral("", null, DataType.NULL);
+  }
 
-    this.value = sourceField.value;
-    this.dataType = sourceField.dataType;
+
+  /**
+   * @param alias The alias for the NULL.
+   * @return A literal representing NULL.
+   */
+  public static FieldLiteral nullLiteral(String alias) {
+    return new FieldLiteral(alias, null, DataType.NULL);
+  }
+
+
+  /**
+   * @param stringValue Any string.
+   * @return A string literal.
+   */
+  public static FieldLiteral literal(final String stringValue) {
+    return new FieldLiteral("", stringValue, DataType.STRING);
+  }
+
+
+  /**
+   * @param value A stringified value.
+   * @param dataType The data type represented by the stringified value.
+   * @return An appropriately typed literal.
+   */
+  public static FieldLiteral literal(final String value, final DataType dataType) {
+    return new FieldLiteral("", value, dataType);
+  }
+
+
+  /**
+   * @param doubleValue Any double.
+   * @return A numeric literal.
+   */
+  public static FieldLiteral literal(final Double doubleValue) {
+    return new FieldLiteral("", doubleValue != null ? doubleValue.toString() : null, DataType.DECIMAL);
+  }
+
+
+  /**
+   * @param bigDecimalValue Any decimal.
+   * @return A numeric literal.
+   */
+  public static FieldLiteral literal(final BigDecimal bigDecimalValue) {
+    return new FieldLiteral("", bigDecimalValue != null ? bigDecimalValue.toPlainString() : null, DataType.DECIMAL);
+  }
+
+
+  /**
+   * @param integerValue Any integer.
+   * @return An integer literal.
+   */
+  public static FieldLiteral literal(final Integer integerValue) {
+    return new FieldLiteral("", integerValue != null ? integerValue.toString() : null, DataType.DECIMAL);
+  }
+
+
+  /**
+   * @param localDateValue Any date.
+   * @return A date literal.
+   */
+  public static FieldLiteral literal(final LocalDate localDateValue) {
+    return new FieldLiteral("", localDateValue != null ? localDateValue.toString("yyyy-MM-dd") : null, DataType.DATE);
+  }
+
+
+  /**
+   * @param longValue Any long.
+   * @return A big integer literal.
+   */
+  public static FieldLiteral literal(final Long longValue) {
+    return new FieldLiteral("", longValue != null ? longValue.toString() : null, DataType.DECIMAL);
+  }
+
+
+  /**
+   * @param charValue Any character.
+   * @return A string literal.
+   */
+  public static FieldLiteral literal(final Character charValue) {
+    return new FieldLiteral("", charValue != null ? charValue.toString() : null, DataType.STRING);
+  }
+
+
+  /**
+   * @param booleanValue Any boolean..
+   * @return A boolean literal.
+   */
+  public static FieldLiteral literal(final Boolean booleanValue) {
+    return new FieldLiteral("", booleanValue != null ? booleanValue.toString() : null, DataType.BOOLEAN);
+  }
+
+
+  /**
+   * TODO make private when {@link NullFieldLiteral} is removed
+   *
+   * @param alias The alias.
+   * @param value The value.
+   * @param dataType The data type.
+   */
+  protected FieldLiteral(final String alias, final String value, final DataType dataType) {
+    super(alias);
+    this.value = value;
+    this.dataType = dataType;
   }
 
 
@@ -58,8 +160,10 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with as string source.
    *
    * @param stringValue the literal value to use
+   * @deprecated Use {@link #literal(String)}
    */
-  public FieldLiteral(String stringValue) {
+  @Deprecated
+  public FieldLiteral(final String stringValue) {
     super();
 
     this.value = stringValue;
@@ -71,8 +175,10 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with as Double source.
    *
    * @param doubleValue the literal value to use
+   * @deprecated Use {@link #literal(Double)}
    */
-  public FieldLiteral(Double doubleValue) {
+  @Deprecated
+  public FieldLiteral(final Double doubleValue) {
     super();
 
     this.value = doubleValue != null ? doubleValue.toString() : null;
@@ -84,8 +190,10 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with a BigDecimal source.
    *
    * @param bigDecimalValue the literal value to use
+   * @deprecated Use {@link #literal(BigDecimal)}
    */
-  public FieldLiteral(BigDecimal bigDecimalValue) {
+  @Deprecated
+  public FieldLiteral(final BigDecimal bigDecimalValue) {
     super();
 
     this.value = bigDecimalValue != null ? bigDecimalValue.toPlainString() : null;
@@ -97,8 +205,10 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with an Integer source.
    *
    * @param integerValue the literal value to use
+   * @deprecated Use {@link #literal(Integer)}
    */
-  public FieldLiteral(Integer integerValue) {
+  @Deprecated
+  public FieldLiteral(final Integer integerValue) {
     super();
 
     this.value = integerValue != null ? integerValue.toString() : null;
@@ -110,8 +220,10 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with a {@link LocalDate} source.
    *
    * @param localDateValue the literal value to use
+   * @deprecated Use {@link #literal(LocalDate)}
    */
-  public FieldLiteral(LocalDate localDateValue) {
+  @Deprecated
+  public FieldLiteral(final LocalDate localDateValue) {
     super();
     this.value = localDateValue != null ? localDateValue.toString("yyyy-MM-dd") : null;
     this.dataType = DataType.DATE;
@@ -122,8 +234,10 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with a Long source.
    *
    * @param longValue the literal value to use
+   * @deprecated Use {@link #literal(Long)}
    */
-  public FieldLiteral(Long longValue) {
+  @Deprecated
+  public FieldLiteral(final Long longValue) {
     super();
 
     this.value = longValue != null ? longValue.toString() : null;
@@ -135,8 +249,10 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with as Character source.
    *
    * @param charValue the literal value to use
+   * @deprecated Use {@link #literal(Character)}
    */
-  public FieldLiteral(Character charValue) {
+  @Deprecated
+  public FieldLiteral(final Character charValue) {
     super();
 
     this.value = charValue != null ? charValue.toString() : null;
@@ -148,8 +264,10 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with as Boolean source.
    *
    * @param booleanValue the literal value to use
+   * @deprecated Use {@link #literal(Boolean)}
    */
-  public FieldLiteral(Boolean booleanValue) {
+  @Deprecated
+  public FieldLiteral(final Boolean booleanValue) {
     super();
 
     this.value = booleanValue != null ? booleanValue.toString() : null;
@@ -161,6 +279,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with a Null source.
    *
    */
+  @Deprecated
   protected FieldLiteral() {
     super();
 
@@ -174,8 +293,10 @@ public class FieldLiteral extends AliasedField {
    *
    * @param value The value of the field.
    * @param dataType The data type of the field.
+   * @deprecated Use {@link #literal(String)} and specify the data type using the builder.
    */
-  public FieldLiteral(String value, DataType dataType) {
+  @Deprecated
+  public FieldLiteral(final String value, final DataType dataType) {
     super();
     this.value = value;
     this.dataType = dataType;
@@ -190,22 +311,22 @@ public class FieldLiteral extends AliasedField {
    */
   public static FieldLiteral fromObject(Object object) {
     if (object instanceof String) {
-      return new FieldLiteral((String) object);
+      return literal((String) object);
     }
 
     if (object instanceof Double) {
-      return new FieldLiteral((Double) object);
+      return literal((Double) object);
     }
 
     if (object instanceof Integer) {
-      return new FieldLiteral((Integer) object);
+      return literal((Integer) object);
     }
 
     if (object instanceof Character) {
-      return new FieldLiteral((Character) object);
+      return literal((Character) object);
     }
 
-    return new FieldLiteral(object.toString());
+    return literal(object.toString());
   }
 
 
@@ -229,8 +350,20 @@ public class FieldLiteral extends AliasedField {
    * @see org.alfasoftware.morf.sql.element.AliasedField#deepCopyInternal(DeepCopyTransformation)
    */
   @Override
-  protected AliasedField deepCopyInternal(DeepCopyTransformation transformer) {
-    return new FieldLiteral(this);
+  protected FieldLiteral deepCopyInternal(final DeepCopyTransformation transformer) {
+    return new FieldLiteral(this.getAlias(), this.value, this.dataType);
+  }
+
+
+  @Override
+  protected AliasedField shallowCopy(String aliasName) {
+    return new FieldLiteral(aliasName, this.value, this.dataType);
+  }
+
+
+  @Override
+  protected boolean refactoredForImmutability() {
+    return true;
   }
 
 
@@ -239,8 +372,40 @@ public class FieldLiteral extends AliasedField {
    */
   @Override
   public FieldLiteral as(String aliasName) {
-    super.as(aliasName);
-    return this;
+    return (FieldLiteral) super.as(aliasName);
+  }
+
+
+  /**
+   * @see java.lang.Object#equals(java.lang.Object)
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    FieldLiteral other = (FieldLiteral) obj;
+    return new EqualsBuilder()
+        .appendSuper(super.equals(obj))
+        .append(this.value, other.value)
+        .append(this.dataType, other.dataType)
+        .isEquals();
+  }
+
+
+  /**
+   * @see java.lang.Object#hashCode()
+   */
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder()
+        .appendSuper(super.hashCode())
+        .append(this.value)
+        .append(this.dataType)
+        .toHashCode();
   }
 
 
@@ -249,6 +414,8 @@ public class FieldLiteral extends AliasedField {
    */
   @Override
   public String toString() {
-    return dataType.equals(DataType.STRING) ? "\"" + value + "\"" : value;
+    return dataType.equals(DataType.STRING)
+        ? "\"" + value + "\""
+        : value == null ? "NULL" : value;
   }
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldLiteral.java
@@ -361,12 +361,6 @@ public class FieldLiteral extends AliasedField {
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * @see org.alfasoftware.morf.sql.element.AliasedField#as(java.lang.String)
    */

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldLiteral.java
@@ -62,7 +62,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param stringValue the literal value to use
    */
-  public FieldLiteral(final String stringValue) {
+  public FieldLiteral(String stringValue) {
     super();
 
     this.value = stringValue;
@@ -75,7 +75,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param doubleValue the literal value to use
    */
-  public FieldLiteral(final Double doubleValue) {
+  public FieldLiteral(Double doubleValue) {
     super();
 
     this.value = doubleValue != null ? doubleValue.toString() : null;
@@ -88,7 +88,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param bigDecimalValue the literal value to use
    */
-  public FieldLiteral(final BigDecimal bigDecimalValue) {
+  public FieldLiteral(BigDecimal bigDecimalValue) {
     super();
 
     this.value = bigDecimalValue != null ? bigDecimalValue.toPlainString() : null;
@@ -101,7 +101,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param integerValue the literal value to use
    */
-  public FieldLiteral(final Integer integerValue) {
+  public FieldLiteral(Integer integerValue) {
     super();
 
     this.value = integerValue != null ? integerValue.toString() : null;
@@ -114,7 +114,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param localDateValue the literal value to use
    */
-  public FieldLiteral(final LocalDate localDateValue) {
+  public FieldLiteral(LocalDate localDateValue) {
     super();
     this.value = localDateValue != null ? localDateValue.toString("yyyy-MM-dd") : null;
     this.dataType = DataType.DATE;
@@ -126,7 +126,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param longValue the literal value to use
    */
-  public FieldLiteral(final Long longValue) {
+  public FieldLiteral(Long longValue) {
     super();
 
     this.value = longValue != null ? longValue.toString() : null;
@@ -139,7 +139,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param charValue the literal value to use
    */
-  public FieldLiteral(final Character charValue) {
+  public FieldLiteral(Character charValue) {
     super();
 
     this.value = charValue != null ? charValue.toString() : null;
@@ -152,7 +152,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param booleanValue the literal value to use
    */
-  public FieldLiteral(final Boolean booleanValue) {
+  public FieldLiteral(Boolean booleanValue) {
     super();
 
     this.value = booleanValue != null ? booleanValue.toString() : null;
@@ -177,7 +177,7 @@ public class FieldLiteral extends AliasedField {
    * @param value The value of the field.
    * @param dataType The data type of the field.
    */
-  public FieldLiteral(final String value, final DataType dataType) {
+  public FieldLiteral(String value, DataType dataType) {
     super();
     this.value = value;
     this.dataType = dataType;

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldLiteral.java
@@ -44,105 +44,6 @@ public class FieldLiteral extends AliasedField {
 
 
   /**
-   * @return A literal representing NULL.
-   */
-  public static FieldLiteral nullLiteral() {
-    return new FieldLiteral("", null, DataType.NULL);
-  }
-
-
-  /**
-   * @param alias The alias for the NULL.
-   * @return A literal representing NULL.
-   */
-  public static FieldLiteral nullLiteral(String alias) {
-    return new FieldLiteral(alias, null, DataType.NULL);
-  }
-
-
-  /**
-   * @param stringValue Any string.
-   * @return A string literal.
-   */
-  public static FieldLiteral literal(final String stringValue) {
-    return new FieldLiteral("", stringValue, DataType.STRING);
-  }
-
-
-  /**
-   * @param value A stringified value.
-   * @param dataType The data type represented by the stringified value.
-   * @return An appropriately typed literal.
-   */
-  public static FieldLiteral literal(final String value, final DataType dataType) {
-    return new FieldLiteral("", value, dataType);
-  }
-
-
-  /**
-   * @param doubleValue Any double.
-   * @return A numeric literal.
-   */
-  public static FieldLiteral literal(final Double doubleValue) {
-    return new FieldLiteral("", doubleValue != null ? doubleValue.toString() : null, DataType.DECIMAL);
-  }
-
-
-  /**
-   * @param bigDecimalValue Any decimal.
-   * @return A numeric literal.
-   */
-  public static FieldLiteral literal(final BigDecimal bigDecimalValue) {
-    return new FieldLiteral("", bigDecimalValue != null ? bigDecimalValue.toPlainString() : null, DataType.DECIMAL);
-  }
-
-
-  /**
-   * @param integerValue Any integer.
-   * @return An integer literal.
-   */
-  public static FieldLiteral literal(final Integer integerValue) {
-    return new FieldLiteral("", integerValue != null ? integerValue.toString() : null, DataType.DECIMAL);
-  }
-
-
-  /**
-   * @param localDateValue Any date.
-   * @return A date literal.
-   */
-  public static FieldLiteral literal(final LocalDate localDateValue) {
-    return new FieldLiteral("", localDateValue != null ? localDateValue.toString("yyyy-MM-dd") : null, DataType.DATE);
-  }
-
-
-  /**
-   * @param longValue Any long.
-   * @return A big integer literal.
-   */
-  public static FieldLiteral literal(final Long longValue) {
-    return new FieldLiteral("", longValue != null ? longValue.toString() : null, DataType.DECIMAL);
-  }
-
-
-  /**
-   * @param charValue Any character.
-   * @return A string literal.
-   */
-  public static FieldLiteral literal(final Character charValue) {
-    return new FieldLiteral("", charValue != null ? charValue.toString() : null, DataType.STRING);
-  }
-
-
-  /**
-   * @param booleanValue Any boolean..
-   * @return A boolean literal.
-   */
-  public static FieldLiteral literal(final Boolean booleanValue) {
-    return new FieldLiteral("", booleanValue != null ? booleanValue.toString() : null, DataType.BOOLEAN);
-  }
-
-
-  /**
    * TODO make private when {@link NullFieldLiteral} is removed
    *
    * @param alias The alias.
@@ -160,9 +61,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with as string source.
    *
    * @param stringValue the literal value to use
-   * @deprecated Use {@link #literal(String)}
    */
-  @Deprecated
   public FieldLiteral(final String stringValue) {
     super();
 
@@ -175,9 +74,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with as Double source.
    *
    * @param doubleValue the literal value to use
-   * @deprecated Use {@link #literal(Double)}
    */
-  @Deprecated
   public FieldLiteral(final Double doubleValue) {
     super();
 
@@ -190,9 +87,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with a BigDecimal source.
    *
    * @param bigDecimalValue the literal value to use
-   * @deprecated Use {@link #literal(BigDecimal)}
    */
-  @Deprecated
   public FieldLiteral(final BigDecimal bigDecimalValue) {
     super();
 
@@ -205,9 +100,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with an Integer source.
    *
    * @param integerValue the literal value to use
-   * @deprecated Use {@link #literal(Integer)}
    */
-  @Deprecated
   public FieldLiteral(final Integer integerValue) {
     super();
 
@@ -220,9 +113,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with a {@link LocalDate} source.
    *
    * @param localDateValue the literal value to use
-   * @deprecated Use {@link #literal(LocalDate)}
    */
-  @Deprecated
   public FieldLiteral(final LocalDate localDateValue) {
     super();
     this.value = localDateValue != null ? localDateValue.toString("yyyy-MM-dd") : null;
@@ -234,9 +125,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with a Long source.
    *
    * @param longValue the literal value to use
-   * @deprecated Use {@link #literal(Long)}
    */
-  @Deprecated
   public FieldLiteral(final Long longValue) {
     super();
 
@@ -249,9 +138,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with as Character source.
    *
    * @param charValue the literal value to use
-   * @deprecated Use {@link #literal(Character)}
    */
-  @Deprecated
   public FieldLiteral(final Character charValue) {
     super();
 
@@ -264,9 +151,7 @@ public class FieldLiteral extends AliasedField {
    * Constructs a new {@linkplain FieldLiteral} with as Boolean source.
    *
    * @param booleanValue the literal value to use
-   * @deprecated Use {@link #literal(Boolean)}
    */
-  @Deprecated
   public FieldLiteral(final Boolean booleanValue) {
     super();
 
@@ -276,11 +161,9 @@ public class FieldLiteral extends AliasedField {
 
 
   /**
-   * Constructs a new {@linkplain FieldLiteral} with a Null source.
-   *
+   * Constructs a new {@linkplain FieldLiteral} representing NULL.
    */
-  @Deprecated
-  protected FieldLiteral() {
+  public FieldLiteral() {
     super();
 
     this.value = null;
@@ -293,9 +176,7 @@ public class FieldLiteral extends AliasedField {
    *
    * @param value The value of the field.
    * @param dataType The data type of the field.
-   * @deprecated Use {@link #literal(String)} and specify the data type using the builder.
    */
-  @Deprecated
   public FieldLiteral(final String value, final DataType dataType) {
     super();
     this.value = value;
@@ -311,22 +192,22 @@ public class FieldLiteral extends AliasedField {
    */
   public static FieldLiteral fromObject(Object object) {
     if (object instanceof String) {
-      return literal((String) object);
+      return new FieldLiteral((String) object);
     }
 
     if (object instanceof Double) {
-      return literal((Double) object);
+      return new FieldLiteral((Double) object);
     }
 
     if (object instanceof Integer) {
-      return literal((Integer) object);
+      return new FieldLiteral((Integer) object);
     }
 
     if (object instanceof Character) {
-      return literal((Character) object);
+      return new FieldLiteral((Character) object);
     }
 
-    return literal(object.toString());
+    return new FieldLiteral(object.toString());
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldReference.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldReference.java
@@ -261,12 +261,6 @@ public class FieldReference extends AliasedField implements Driver {
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * @see org.alfasoftware.morf.util.ObjectTreeTraverser.Driver#drive(ObjectTreeTraverser)
    */

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldReference.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldReference.java
@@ -15,6 +15,8 @@
 
 package org.alfasoftware.morf.sql.element;
 
+import static org.alfasoftware.morf.util.DeepCopyTransformations.noTransformation;
+
 import org.alfasoftware.morf.util.DeepCopyTransformation;
 import org.alfasoftware.morf.util.ObjectTreeTraverser;
 import org.alfasoftware.morf.util.ObjectTreeTraverser.Driver;
@@ -33,15 +35,15 @@ import com.google.common.base.Optional;
  *
  * <p>Create a field with a given name:</p>
  * <blockquote><pre>
- *    Field newField = new Field("agreementnumber");</pre></blockquote>
+ *    AliasedField newField = field("agreementnumber").build();</pre></blockquote>
  *
  * <p>Create a field with a given name and alias of "bob". This is equivalent to "agreementnumber AS bob" in SQL:</p>
  * <blockquote><pre>
- *    Field newField = new Field("agreementnumber", "bob");</pre></blockquote>
+ *    AliasedField newField = field("agreementnumber", "bob").build();</pre></blockquote>
  *
  * <p>Create a field which is sorted descending:</p>
  * <blockquote><pre>
- *    Field newField = new Field("agreementnumber", Direction.DESCENDING);</pre></blockquote>
+ *    AliasedField newField = field("agreementnumber").asc().build();</pre></blockquote>
  *
  * @author Copyright (c) Alfa Financial Software 2009
  */
@@ -58,14 +60,40 @@ public class FieldReference extends AliasedField implements Driver {
   private final String name;
 
   /**
-   * The direction to use when this field is in an ORDER BY statement
+   * The direction to use when this field is in an ORDER BY statement.
+   * TODO this should be final as soon as we can remove {@link #setDirection(Direction)}
+   * and {@link AliasedField#IMMUTABLE_BUILDERS_ENABLED}.
    */
   private Direction direction;
 
   /**
-   * Handling of null values when executing ORDER BY statement
+   * Handling of null values when executing ORDER BY statement.
+   * TODO this vcan be made final when we remove {@link AliasedField#IMMUTABLE_BUILDERS_ENABLED}
    */
-  private Optional<NullValueHandling> nullValueHandling = Optional.absent();
+  private Optional<NullValueHandling> nullValueHandling;
+
+
+  /**
+   * Constructs a new field with an alias on a given table.
+   *
+   * @param name the name of the field.
+   * @return The field reference.
+   */
+  public static Builder field(String name) {
+    return new Builder(null, name);
+  }
+
+
+  /**
+   * Constructs a new field with an alias on a given table.
+   *
+   * @param table the table on which the field exists
+   * @param name the name of the field.
+   * @return The field reference.
+   */
+  public static Builder field(TableReference table, String name) {
+    return new Builder(table, name);
+  }
 
 
   /**
@@ -73,14 +101,17 @@ public class FieldReference extends AliasedField implements Driver {
    *
    * @param sourceField the field reference to create the copy from
    * @param transformer The transformation to be executed during the copy
+   * @deprecated Use {@link #field(TableReference, String)}
    */
+  @Deprecated
   protected FieldReference(FieldReference sourceField, DeepCopyTransformation transformer) {
-    super();
-
-    this.table = transformer.deepCopy(sourceField.table);
-    this.name = sourceField.name;
-    this.direction = sourceField.direction;
-    this.nullValueHandling = sourceField.nullValueHandling;
+    this(
+        sourceField.getAlias(),
+        transformer.deepCopy(sourceField.table),
+        sourceField.name,
+        sourceField.direction,
+        sourceField.nullValueHandling
+    );
   }
 
 
@@ -91,14 +122,16 @@ public class FieldReference extends AliasedField implements Driver {
    * @param name the name of the field
    * @param direction the sort direction of the field
    * @param nullValueHandling how to handle nulls
+   * @deprecated Use {@link #field(TableReference, String)}
    */
+  @Deprecated
   public FieldReference(TableReference table, String name, Direction direction, NullValueHandling nullValueHandling) {
-    this(table, name, direction, Optional.of(nullValueHandling));
+    this("", table, name, direction, Optional.of(nullValueHandling));
   }
 
 
-  private FieldReference(TableReference table, String name, Direction direction, Optional<NullValueHandling> nullValueHandling) {
-    super();
+  private FieldReference(String alias, TableReference table, String name, Direction direction, Optional<NullValueHandling> nullValueHandling) {
+    super(alias);
     this.table = table;
     this.name = name;
     this.direction = direction;
@@ -112,9 +145,11 @@ public class FieldReference extends AliasedField implements Driver {
    * @param table the table on which the field exists
    * @param name the name of the field
    * @param direction the sort direction of the field
+   * @deprecated Use {@link #field(TableReference, String)}
    */
+  @Deprecated
   public FieldReference(TableReference table, String name, Direction direction) {
-    this(table, name, direction, Optional.<NullValueHandling>absent());
+    this("", table, name, direction, Optional.<NullValueHandling>absent());
   }
 
 
@@ -123,9 +158,11 @@ public class FieldReference extends AliasedField implements Driver {
    *
    * @param table the table on which the field exists
    * @param name the name of the field
+   * @deprecated Use {@link #field(TableReference, String)}
    */
+  @Deprecated
   public FieldReference(TableReference table, String name) {
-    this(table, name, Direction.NONE);
+    this("", table, name, Direction.NONE, Optional.<NullValueHandling>absent());
   }
 
 
@@ -133,9 +170,11 @@ public class FieldReference extends AliasedField implements Driver {
    * Constructs a new field with a given name
    *
    * @param name the name of the field
+   * @deprecated Use {@link #field(TableReference, String)}
    */
+  @Deprecated
   public FieldReference(String name) {
-    this(null, name);
+    this("", null, name, Direction.NONE, Optional.<NullValueHandling>absent());
   }
 
 
@@ -144,9 +183,11 @@ public class FieldReference extends AliasedField implements Driver {
    *
    * @param name the name of the field
    * @param direction the sort direction for the field
+   * @deprecated Use {@link #field(TableReference, String)}
    */
+  @Deprecated
   public FieldReference(String name, Direction direction) {
-    this(null, name, direction);
+    this("", null, name, direction, Optional.<NullValueHandling>absent());
   }
 
 
@@ -194,8 +235,12 @@ public class FieldReference extends AliasedField implements Driver {
    * Sets the direction to sort the field on.
    *
    * @param direction the direction to set
+   * @deprecated Use {@link #direction(Direction)}
    */
+  @Deprecated
   public void setDirection(Direction direction) {
+    if (immutableDslEnabled())
+      throw new UnsupportedOperationException("setDirection method not supported when IMMUTABLE_BUILDERS_ENABLED");
     this.direction = direction;
   }
 
@@ -205,8 +250,20 @@ public class FieldReference extends AliasedField implements Driver {
    * @see org.alfasoftware.morf.sql.element.AliasedField#deepCopyInternal(DeepCopyTransformation)
    */
   @Override
-  protected AliasedField deepCopyInternal(DeepCopyTransformation transformer) {
-    return new FieldReference(this,transformer);
+  protected FieldReference deepCopyInternal(DeepCopyTransformation transformer) {
+    return new FieldReference(getAlias(), transformer.deepCopy(table), name, direction, nullValueHandling);
+  }
+
+
+  @Override
+  protected AliasedField shallowCopy(String aliasName) {
+    return new FieldReference(aliasName, table, name, direction, nullValueHandling);
+  }
+
+
+  @Override
+  protected boolean refactoredForImmutability() {
+    return true;
   }
 
 
@@ -242,9 +299,11 @@ public class FieldReference extends AliasedField implements Driver {
     if (this == obj) {
       return true;
     }
+    // TODO incorrect - permits other types. Can't change this - need to fix existing misuse in subtypes
     if (obj instanceof FieldReference) {
       FieldReference other = (FieldReference) obj;
       return new EqualsBuilder()
+                  .appendSuper(super.equals(obj))
                   .append(this.direction, other.direction)
                   .append(this.name, other.name)
                   .append(this.nullValueHandling, other.nullValueHandling)
@@ -261,6 +320,7 @@ public class FieldReference extends AliasedField implements Driver {
   @Override
   public int hashCode() {
     return new HashCodeBuilder()
+        .appendSuper(super.hashCode())
         .append(direction)
         .append(name)
         .append(nullValueHandling)
@@ -277,13 +337,18 @@ public class FieldReference extends AliasedField implements Driver {
     return StringUtils.isBlank(super.getImpliedName()) ? getName() : super.getImpliedName();
   }
 
+
   /**
    * sets descending order on this field
    * @return this
    */
   public FieldReference desc() {
-    this.direction = Direction.DESCENDING;
-    return this;
+    if (immutableDslEnabled()) {
+      return new Builder(noTransformation(), this).desc().build();
+    } else {
+      this.direction = Direction.DESCENDING;
+      return this;
+    }
   }
 
 
@@ -292,8 +357,12 @@ public class FieldReference extends AliasedField implements Driver {
    * @return this
    */
   public FieldReference asc() {
-    this.direction = Direction.ASCENDING;
-    return this;
+    if (immutableDslEnabled()) {
+      return new Builder(noTransformation(), this).asc().build();
+    } else {
+      this.direction = Direction.ASCENDING;
+      return this;
+    }
   }
 
 
@@ -302,8 +371,12 @@ public class FieldReference extends AliasedField implements Driver {
    * @return this
    */
   public FieldReference nullsLast() {
-    this.nullValueHandling = Optional.of(NullValueHandling.LAST);
-    return this;
+    if (immutableDslEnabled()) {
+      return new Builder(noTransformation(), this).nullsLast().build();
+    } else {
+      this.nullValueHandling = Optional.of(NullValueHandling.LAST);
+      return this;
+    }
   }
 
 
@@ -312,16 +385,142 @@ public class FieldReference extends AliasedField implements Driver {
    * @return this
    */
   public FieldReference nullsFirst() {
-    this.nullValueHandling = Optional.of(NullValueHandling.FIRST);
-    return this;
+    if (immutableDslEnabled()) {
+      return new Builder(noTransformation(), this).nullsFirst().build();
+    } else {
+      this.nullValueHandling = Optional.of(NullValueHandling.FIRST);
+      return this;
+    }
   }
+
 
   /**
    * sets null value handling type to none
    * @return this
    */
   public FieldReference noNullHandling() {
-    this.nullValueHandling = Optional.of(NullValueHandling.NONE);
-    return this;
+    if (immutableDslEnabled()) {
+      return new Builder(noTransformation(), this).noNullHandling().build();
+    } else {
+      this.nullValueHandling = Optional.of(NullValueHandling.NONE);
+      return this;
+    }
+  }
+
+
+  /**
+   * Sets the direction to sort the field on.
+   *
+   * @param direction the direction to set
+   * @return this
+   */
+  public FieldReference direction(Direction direction) {
+    return new Builder(noTransformation(), this).direction(direction).build();
+  }
+
+
+  /**
+   * Builder for {@link FieldReference}.
+   */
+  public static final class Builder implements AliasedFieldBuilder {
+
+    private final TableReference table;
+    private final String name;
+
+    private String alias;
+    private Direction direction = Direction.NONE;
+    private Optional<NullValueHandling> nullValueHandling = Optional.absent();
+
+    private Builder(DeepCopyTransformation transformer, FieldReference copyOf) {
+      this.alias = copyOf.getAlias();
+      this.table = transformer.deepCopy(copyOf.table);
+      this.name = copyOf.name;
+      this.direction = copyOf.direction;
+      this.nullValueHandling = copyOf.nullValueHandling;
+    }
+
+    private Builder(TableReference table, String name) {
+      this.alias = "";
+      this.table = table;
+      this.name = name;
+    }
+
+    /**
+     * sets descending order on this field
+     * @return this
+     */
+    public Builder desc() {
+      this.direction = Direction.DESCENDING;
+      return this;
+    }
+
+    /**
+     * sets ascending order on this field
+     * @return this
+     */
+    public Builder asc() {
+      this.direction = Direction.ASCENDING;
+      return this;
+    }
+
+    /**
+     * sets null value handling type to last
+     * @return this
+     */
+    public Builder nullsLast() {
+      this.nullValueHandling = Optional.of(NullValueHandling.LAST);
+      return this;
+    }
+
+    /**
+     * sets null value handling type to first
+     * @return this
+     */
+    public Builder nullsFirst() {
+      this.nullValueHandling = Optional.of(NullValueHandling.FIRST);
+      return this;
+    }
+
+    /**
+     * sets null value handling type to none
+     * @return this
+     */
+    public Builder noNullHandling() {
+      this.nullValueHandling = Optional.of(NullValueHandling.NONE);
+      return this;
+    }
+
+    /**
+     * Sets the direction to sort the field on.
+     *
+     * @param direction the direction to set
+     * @return this
+     */
+    public Builder direction(Direction direction) {
+      this.direction = direction;
+      return this;
+    }
+
+    /**
+     * Specifies the alias to use for the field.
+     *
+     * @param aliasName the name of the alias
+     * @return this
+     */
+    @Override
+    public Builder as(String aliasName) {
+      this.alias = aliasName;
+      return this;
+    }
+
+    /**
+     * Builds the {@link FieldReference}.
+     *
+     * @return The field reference.
+     */
+    @Override
+    public FieldReference build() {
+      return new FieldReference(alias, table, name, direction, nullValueHandling);
+    }
   }
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldReference.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FieldReference.java
@@ -122,9 +122,7 @@ public class FieldReference extends AliasedField implements Driver {
    * @param name the name of the field
    * @param direction the sort direction of the field
    * @param nullValueHandling how to handle nulls
-   * @deprecated Use {@link #field(TableReference, String)}
    */
-  @Deprecated
   public FieldReference(TableReference table, String name, Direction direction, NullValueHandling nullValueHandling) {
     this("", table, name, direction, Optional.of(nullValueHandling));
   }
@@ -145,9 +143,7 @@ public class FieldReference extends AliasedField implements Driver {
    * @param table the table on which the field exists
    * @param name the name of the field
    * @param direction the sort direction of the field
-   * @deprecated Use {@link #field(TableReference, String)}
    */
-  @Deprecated
   public FieldReference(TableReference table, String name, Direction direction) {
     this("", table, name, direction, Optional.<NullValueHandling>absent());
   }
@@ -158,9 +154,7 @@ public class FieldReference extends AliasedField implements Driver {
    *
    * @param table the table on which the field exists
    * @param name the name of the field
-   * @deprecated Use {@link #field(TableReference, String)}
    */
-  @Deprecated
   public FieldReference(TableReference table, String name) {
     this("", table, name, Direction.NONE, Optional.<NullValueHandling>absent());
   }
@@ -170,9 +164,7 @@ public class FieldReference extends AliasedField implements Driver {
    * Constructs a new field with a given name
    *
    * @param name the name of the field
-   * @deprecated Use {@link #field(TableReference, String)}
    */
-  @Deprecated
   public FieldReference(String name) {
     this("", null, name, Direction.NONE, Optional.<NullValueHandling>absent());
   }
@@ -183,9 +175,7 @@ public class FieldReference extends AliasedField implements Driver {
    *
    * @param name the name of the field
    * @param direction the sort direction for the field
-   * @deprecated Use {@link #field(TableReference, String)}
    */
-  @Deprecated
   public FieldReference(String name, Direction direction) {
     this("", null, name, direction, Optional.<NullValueHandling>absent());
   }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Function.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Function.java
@@ -15,6 +15,8 @@
 
 package org.alfasoftware.morf.sql.element;
 
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
+
 import java.util.List;
 
 import org.alfasoftware.morf.metadata.DataType;
@@ -480,7 +482,7 @@ public final class Function extends AliasedField implements Driver {
    * @return an instance of LPAD function.
    */
   public static Function leftPad(AliasedField field, int length, String character) {
-    return new Function(FunctionType.LEFT_PAD, field, FieldLiteral.literal(length), FieldLiteral.literal(character));
+    return new Function(FunctionType.LEFT_PAD, field, literal(length), literal(character));
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Function.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Function.java
@@ -509,12 +509,6 @@ public final class Function extends AliasedField implements Driver {
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * @see org.alfasoftware.morf.util.ObjectTreeTraverser.Driver#drive(ObjectTreeTraverser)
    */

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/MathsField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/MathsField.java
@@ -15,7 +15,7 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.BracketedExpression.bracket;
+import static org.alfasoftware.morf.sql.SqlUtils.bracket;
 
 import org.alfasoftware.morf.util.DeepCopyTransformation;
 import org.alfasoftware.morf.util.ObjectTreeTraverser;

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/MathsField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/MathsField.java
@@ -15,6 +15,8 @@
 
 package org.alfasoftware.morf.sql.element;
 
+import static org.alfasoftware.morf.sql.element.BracketedExpression.bracket;
+
 import org.alfasoftware.morf.util.DeepCopyTransformation;
 import org.alfasoftware.morf.util.ObjectTreeTraverser;
 import org.alfasoftware.morf.util.ObjectTreeTraverser.Driver;
@@ -51,7 +53,14 @@ public class MathsField extends AliasedField implements Driver {
    */
   public MathsField(AliasedField leftField, MathsOperator operator, AliasedField rightField) {
     super();
+    this.leftField = leftField;
+    this.operator = operator;
+    this.rightField = rightField;
+  }
 
+
+  private MathsField(String alias, AliasedField leftField, MathsOperator operator, AliasedField rightField) {
+    super(alias);
     this.leftField = leftField;
     this.operator = operator;
     this.rightField = rightField;
@@ -87,7 +96,19 @@ public class MathsField extends AliasedField implements Driver {
    */
   @Override
   protected AliasedField deepCopyInternal(DeepCopyTransformation transformer) {
-    return new MathsField( transformer.deepCopy(leftField), operator, transformer.deepCopy(rightField));
+    return new MathsField(this.getAlias(), transformer.deepCopy(leftField), operator, transformer.deepCopy(rightField));
+  }
+
+
+  @Override
+  protected AliasedField shallowCopy(String aliasName) {
+    return new MathsField(aliasName, leftField, operator, rightField);
+  }
+
+
+  @Override
+  protected boolean refactoredForImmutability() {
+    return true;
   }
 
 
@@ -98,7 +119,7 @@ public class MathsField extends AliasedField implements Driver {
    * @return The function representing the sum
    */
   public static MathsField plus(AliasedField leftField, AliasedField rightField ) {
-    AliasedField rightOperand = rightField instanceof MathsField ? new BracketedExpression((MathsField)rightField) : rightField;
+    AliasedField rightOperand = rightField instanceof MathsField ? bracket((MathsField)rightField) : rightField;
     return new MathsField(leftField, MathsOperator.PLUS, rightOperand);
   }
 
@@ -110,7 +131,7 @@ public class MathsField extends AliasedField implements Driver {
    * @return The function representing the product
    */
   public static MathsField multiply(AliasedField leftField, AliasedField rightField ) {
-    AliasedField rightOperand = rightField instanceof MathsField ? new BracketedExpression((MathsField)rightField) : rightField;
+    AliasedField rightOperand = rightField instanceof MathsField ? bracket((MathsField)rightField) : rightField;
     return new MathsField(leftField, MathsOperator.MULTIPLY, rightOperand);
   }
 
@@ -123,6 +144,42 @@ public class MathsField extends AliasedField implements Driver {
     traverser
       .dispatch(getLeftField())
       .dispatch(getRightField());
+  }
+
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = super.hashCode();
+    result = prime * result + ((leftField == null) ? 0 : leftField.hashCode());
+    result = prime * result + ((operator == null) ? 0 : operator.hashCode());
+    result = prime * result + ((rightField == null) ? 0 : rightField.hashCode());
+    return result;
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (!super.equals(obj))
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    MathsField other = (MathsField) obj;
+    if (leftField == null) {
+      if (other.leftField != null)
+        return false;
+    } else if (!leftField.equals(other.leftField))
+      return false;
+    if (operator != other.operator)
+      return false;
+    if (rightField == null) {
+      if (other.rightField != null)
+        return false;
+    } else if (!rightField.equals(other.rightField))
+      return false;
+    return true;
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/MathsField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/MathsField.java
@@ -106,12 +106,6 @@ public class MathsField extends AliasedField implements Driver {
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * Provides the plus operation for SQL.
    * @param leftField left addendum

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/NullFieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/NullFieldLiteral.java
@@ -23,9 +23,7 @@ import org.alfasoftware.morf.util.DeepCopyTransformation;
  * Provides a representation of a null literal field value to be used in a {@link Statement}.
  *
  * @author Copyright (c) Alfa Financial Software 2010
- * @deprecated Use {@link FieldLiteral#nullLiteral()}.
  */
-@Deprecated
 public class NullFieldLiteral extends FieldLiteral {
 
   public NullFieldLiteral() {
@@ -44,5 +42,4 @@ public class NullFieldLiteral extends FieldLiteral {
   protected NullFieldLiteral deepCopyInternal(final DeepCopyTransformation transformer) {
     return new NullFieldLiteral(this.getAlias());
   }
-
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/NullFieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/NullFieldLiteral.java
@@ -15,28 +15,34 @@
 
 package org.alfasoftware.morf.sql.element;
 
+import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.sql.Statement;
 import org.alfasoftware.morf.util.DeepCopyTransformation;
-import org.apache.commons.lang.StringUtils;
 
 /**
  * Provides a representation of a null literal field value to be used in a {@link Statement}.
  *
  * @author Copyright (c) Alfa Financial Software 2010
+ * @deprecated Use {@link FieldLiteral#nullLiteral()}.
  */
+@Deprecated
 public class NullFieldLiteral extends FieldLiteral {
+
+  public NullFieldLiteral() {
+    super();
+  }
+
+
+  NullFieldLiteral(String alias) {
+    super(alias, null, DataType.NULL);
+  }
 
   /**
    * @see org.alfasoftware.morf.sql.element.AliasedField#deepCopyInternal(DeepCopyTransformation)
    */
   @Override
-  protected AliasedField deepCopyInternal(DeepCopyTransformation transformer) {
-    return new NullFieldLiteral();
+  protected NullFieldLiteral deepCopyInternal(final DeepCopyTransformation transformer) {
+    return new NullFieldLiteral(this.getAlias());
   }
 
-
-  @Override
-  public String toString() {
-    return "NULL" + (StringUtils.isEmpty(getAlias()) ? "" : " AS " + getAlias());
-  }
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/SqlParameter.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/SqlParameter.java
@@ -88,9 +88,7 @@ parameter("name").type(DataType.DECIMAL).width(13,2).build();</pre>
    * Constructs a new SQL field parameter.
    *
    * @param metadata The parameter metadata
-   * @deprecated Use {@link #parameter(String)}.
    */
-  @Deprecated
   public SqlParameter(Column metadata) {
     this(metadata.getName(), metadata.getType(), metadata.getWidth(), metadata.getScale());
   }

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/SqlParameter.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/SqlParameter.java
@@ -142,12 +142,6 @@ parameter("name").type(DataType.DECIMAL).width(13,2).build();</pre>
   }
 
 
-  @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
   /**
    * Returns the field metadata for the parameter.
    *

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/WhenCondition.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/WhenCondition.java
@@ -34,7 +34,7 @@ public class WhenCondition implements Driver,DeepCopyableWithTransformation<When
   /** Value */
   private final AliasedField value;
 
-  /** Criterion*/
+  /** Criterion */
   private final Criterion criterion;
 
   /**
@@ -83,7 +83,7 @@ public class WhenCondition implements Driver,DeepCopyableWithTransformation<When
    * @return deep copy of the field
    */
   public WhenCondition deepCopy() {
-    return new WhenCondition(this,DeepCopyTransformations.noTransformation());
+    return new WhenCondition(this, DeepCopyTransformations.noTransformation());
   }
 
 
@@ -95,6 +95,39 @@ public class WhenCondition implements Driver,DeepCopyableWithTransformation<When
     traverser
       .dispatch(getCriterion())
       .dispatch(getValue());
+  }
+
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + ((criterion == null) ? 0 : criterion.hashCode());
+    result = prime * result + ((value == null) ? 0 : value.hashCode());
+    return result;
+  }
+
+
+  @Override
+  public boolean equals(Object obj) {
+    if (this == obj)
+      return true;
+    if (obj == null)
+      return false;
+    if (getClass() != obj.getClass())
+      return false;
+    WhenCondition other = (WhenCondition) obj;
+    if (criterion == null) {
+      if (other.criterion != null)
+        return false;
+    } else if (!criterion.equals(other.criterion))
+      return false;
+    if (value == null) {
+      if (other.value != null)
+        return false;
+    } else if (!value.equals(other.value))
+      return false;
+    return true;
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/WindowFunction.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/WindowFunction.java
@@ -103,7 +103,7 @@ public final class WindowFunction extends AliasedField implements Driver {
    *
    * @author Copyright (c) Alfa Financial Software 2017
    */
-  public interface Builder {
+  public interface Builder extends AliasedFieldBuilder {
 
     /**
      * Specifies the fields to include in the ORDER BY clause of the window
@@ -151,6 +151,7 @@ public final class WindowFunction extends AliasedField implements Driver {
      * @param alias the name of the alias
      * @return the window function builder.
      */
+    @Override
     Builder as(String alias);
 
 
@@ -159,6 +160,7 @@ public final class WindowFunction extends AliasedField implements Driver {
      *
      * @return The window function.
      */
+    @Override
     WindowFunction build();
   }
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/WindowFunction.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/WindowFunction.java
@@ -279,12 +279,6 @@ public final class WindowFunction extends AliasedField implements Driver {
 
 
   @Override
-  protected boolean refactoredForImmutability() {
-    return true;
-  }
-
-
-  @Override
   public int hashCode() {
     final int prime = 31;
     int result = super.hashCode();

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/HumanReadableStatementHelper.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/HumanReadableStatementHelper.java
@@ -46,7 +46,6 @@ import org.alfasoftware.morf.sql.element.Function;
 import org.alfasoftware.morf.sql.element.FunctionType;
 import org.alfasoftware.morf.sql.element.Join;
 import org.alfasoftware.morf.sql.element.MathsField;
-import org.alfasoftware.morf.sql.element.NullFieldLiteral;
 import org.alfasoftware.morf.sql.element.Operator;
 import org.alfasoftware.morf.sql.element.TableReference;
 import org.alfasoftware.morf.sql.element.WhenCondition;
@@ -1051,9 +1050,7 @@ class HumanReadableStatementHelper {
    * @return a string containing the literal value.
    */
   private static String generateFieldValueString(final AliasedField field) {
-    if (field instanceof NullFieldLiteral) {
-      return "null";
-    } else if (field instanceof CaseStatement) {
+    if (field instanceof CaseStatement) {
       final StringBuilder sb = new StringBuilder("(");
       for (WhenCondition when : ((CaseStatement)field).getWhenConditions()) {
         if (sb.length() > 1) {

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/TestObjectTreeTraverserWithSqlElementVisitor.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/TestObjectTreeTraverserWithSqlElementVisitor.java
@@ -304,7 +304,7 @@ public class TestObjectTreeTraverserWithSqlElementVisitor {
    */
   @Test
   public void testMerge() {
-    final SelectStatement select = select(literal(1), literal(1)).from(two);
+    final SelectStatement select = select(literal(1), literal(2)).from(two);
     final MergeStatement merge = merge().into(three).from(select);
 
     traverser.dispatch(merge);
@@ -397,7 +397,7 @@ public class TestObjectTreeTraverserWithSqlElementVisitor {
   @Test
   public void testInsertFromFieldsAndValues() {
     final SelectStatement select1 = select(literal(1)).from(two);
-    final SelectStatement select2 = select(literal(1)).from(four);
+    final SelectStatement select2 = select(literal(2)).from(four);
 
     final FieldFromSelect select1AsField = (FieldFromSelect) select1.asField().as("a");
     final FieldFromSelect select2AsField = (FieldFromSelect) select2.asField().as("b");
@@ -432,7 +432,7 @@ public class TestObjectTreeTraverserWithSqlElementVisitor {
   @Test
   public void testInsertFromFields() {
     final SelectStatement select1 = select(literal(1)).from(two);
-    final SelectStatement select2 = select(literal(1)).from(four);
+    final SelectStatement select2 = select(literal(2)).from(four);
 
     final FieldFromSelect select1AsField = (FieldFromSelect) select1.asField().as("a");
     final FieldFromSelect select2AsField = (FieldFromSelect) select2.asField().as("b");

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/AbstractAliasedFieldTest.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/AbstractAliasedFieldTest.java
@@ -1,0 +1,204 @@
+package org.alfasoftware.morf.sql.element;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.function.Supplier;
+
+import org.alfasoftware.morf.sql.SelectStatement;
+import org.alfasoftware.morf.sql.TempTransitionalBuilderWrapper;
+import org.alfasoftware.morf.util.Builder;
+import org.alfasoftware.morf.util.DeepCopyTransformation;
+import org.alfasoftware.morf.util.DeepCopyableWithTransformation;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.mockito.Mockito;
+
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Common tests that all SQL elements must satisfy.
+ *
+ * @author Copyright (c) Alfa Financial Software 2017
+ */
+public abstract class AbstractAliasedFieldTest<T extends AliasedField> {
+
+  @Parameter(value = 0)
+  public String testName;
+
+  @Parameter(value = 1)
+  public Supplier<T> onTestSupplier;
+
+  @Parameter(value = 2)
+  public ImmutableList<Supplier<T>> notEqualSupplier;
+
+  protected T onTest;
+  private ImmutableList<T> notEqual;
+  private T isEqual;
+  protected AliasedField onTestAliased;
+  private AliasedField isEqualAliased;
+  private AliasedField notEqualDueToAlias;
+
+  private static int mockCounter;
+
+
+  /**
+   * Creates a test case for the test parameters.
+   *
+   * @param name The test name.
+   * @param onTest A lambda which will create an instance of the {@link AliasedField}
+   *          under test. This will be called multiple times to confirm that
+   *          identical copies are equivalent.
+   * @param notEqual A lambda which will create an instance that does NOT equal
+   *          {@code onTest}. This will be confirmed.
+   * @return The test case.
+   */
+  @SafeVarargs
+  protected static <T> Object[] testCase(
+      String name,
+      Supplier<T> onTest,
+      Supplier<T>... notEqual) {
+    return new Object[] { name, onTest, ImmutableList.copyOf(notEqual) };
+  }
+
+
+  @Before
+  public void setup() {
+    this.onTest = onTestSupplier.get();
+    this.isEqual = onTestSupplier.get();
+    this.notEqual = FluentIterable.from(notEqualSupplier).transform(Supplier::get).toList();
+    this.onTestAliased = onTestSupplier.get().as("A");
+    this.isEqualAliased = onTestSupplier.get().as("A");
+    this.notEqualDueToAlias = onTestSupplier.get().as("B");
+  }
+
+
+  protected static SelectStatement mockSelectStatement() {
+    return mockOf(SelectStatement.class);
+  }
+
+  protected static TableReference mockTableReference() {
+    return mockOf(TableReference.class);
+  }
+
+  protected static <T extends DeepCopyableWithTransformation<T, Builder<T>>> T mockOf(Class<T> clazz) {
+    T mock = mock(clazz);
+    when(mock.deepCopy(Mockito.any(DeepCopyTransformation.class))).thenReturn(TempTransitionalBuilderWrapper.wrapper(mock));
+    when(mock.toString()).thenReturn(mock.getClass().getSimpleName() + mockCounter++);
+    return mock;
+  }
+
+  /**
+   * Confirms that hashcodes for equivalent objects match.
+   */
+  @Test
+  public void testHashCode() {
+    assertEquals(isEqual.hashCode(), onTest.hashCode());
+    assertEquals(isEqualAliased.hashCode(), onTestAliased.hashCode());
+  }
+
+  /**
+   * Confirms correct behaviour of the "as" method.
+   */
+  @Test
+  public void testAs() {
+    AliasedField.withImmutableBuildersEnabled(() -> {
+      assertEquals(isEqual.as("A"), onTest.as("A"));
+      assertEquals(isEqual.as("B").as("A"), onTest.as("A"));
+      assertNotEquals(isEqual.as("A"), onTest.as("B"));
+      assertNotSame(onTest, onTest.as("A"));
+    });
+
+    // Should get the same object with immutable builders off
+    assertSame(onTest, onTest.as("A"));
+  }
+
+  /**
+   * Compares the toString to the default implementation to make sure it's been defined.
+   */
+  @Test
+  public void testToStringHasBeenDefined() {
+    assertNotEquals(defaultToString(onTest), onTest.toString());
+  }
+
+  /**
+   * Tests that the assumption {@link #testToStringHasBeenDefined()} makes
+   * (about the behaviour of the default toString method) is correct.  If this
+   * predicate fails, we won't be correctly testing that toString works.
+   */
+  @Test
+  public void testToStringAssumptionTrue() {
+    Object o = new Object();
+    assertEquals(defaultToString(o), o.toString());
+  }
+
+
+  private String defaultToString(Object o) {
+    return o.getClass().getName() + "@" + Integer.toHexString(o.hashCode());
+  }
+
+  /**
+   * Ensures that identically constructed instances equal each other, non-identical ones
+   * don't, and that alias is taken into account.
+   */
+  @Test
+  public void testEquals() {
+    assertEquals(isEqual, onTest);
+    assertFalse(onTest.equals(null));
+    notEqual.forEach(ne -> assertNotEquals(ne, onTest));
+    assertEquals(isEqualAliased, onTestAliased);
+    assertNotEquals(notEqualDueToAlias, onTestAliased);
+  }
+
+  /**
+   * Ensures that deep copies match.
+   */
+  @Test
+  public void testDeepCopy() {
+    AliasedField deepCopy = onTest.deepCopy();
+    assertEquals(deepCopy, onTest);
+    assertNotSame(deepCopy, onTest);
+  }
+
+  /**
+   * Ensures that deep copies with aliases match.
+   */
+  @Test
+  public void testDeepCopyAliased() {
+    AliasedField deepCopy = onTestAliased.deepCopy();
+    assertEquals(deepCopy, onTestAliased);
+    assertNotSame(deepCopy, onTestAliased);
+  }
+
+  /**
+   * Confirms that the implied name returns the alias, assuming we
+   * are maintain the old, mutable behaviour of the as method
+   */
+  @Test
+  public void testImpliedNameMutableBehaviour() {
+    onTest.as("QWERTY");
+    assertEquals(onTest.getImpliedName(), "QWERTY");
+  }
+
+
+  /**
+   * Confirms that the implied name returns the alias, assuming
+   * the as method now returns a new instance.
+   */
+  @Test
+  public void testImpliedNameImmutableBehaviour() {
+    AliasedField.withImmutableBuildersEnabled(() -> {
+      String originalImpliedName = onTest.getImpliedName();
+      onTest.as("QWERTY");
+      assertEquals(onTest.getImpliedName(), originalImpliedName);
+      assertEquals(onTest.as("QWERTY").getImpliedName(), "QWERTY");
+    });
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/AbstractDeepCopyableTest.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/AbstractDeepCopyableTest.java
@@ -1,0 +1,134 @@
+/* Copyright 2017 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.alfasoftware.morf.sql.element;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.List;
+import java.util.function.Supplier;
+
+import org.alfasoftware.morf.sql.TempTransitionalBuilderWrapper;
+import org.alfasoftware.morf.util.Builder;
+import org.alfasoftware.morf.util.DeepCopyTransformation;
+import org.alfasoftware.morf.util.DeepCopyTransformations;
+import org.alfasoftware.morf.util.DeepCopyableWithTransformation;
+import org.junit.Test;
+import org.junit.runners.Parameterized.Parameter;
+import org.mockito.Mockito;
+
+/**
+ * Tests that must pass for anything implementing {@link DeepCopyableWithTransformation}.
+ * There are more specific tests for {@link AbstractAliasedFieldTest} and
+ * {@link TestTableReference}.
+ *
+ * @author Copyright (c) Alfa Financial Software 2017
+ */
+public abstract class AbstractDeepCopyableTest<T extends DeepCopyableWithTransformation<T, Builder<T>>> {
+
+  @Parameter(value = 0) public String testName;
+  @Parameter(value = 1) public Supplier<T> onTest;
+
+  private static int mockCounter;
+
+
+  protected static <T extends DeepCopyableWithTransformation<T, Builder<T>>> Object[] testCase(String name, Supplier<T> onTest) {
+    return new Object[] { name, onTest };
+  }
+
+  protected static <T extends DeepCopyableWithTransformation<T, Builder<T>>> T mockOf(Class<T> clazz) {
+    T mock = mock(clazz);
+    when(mock.deepCopy(Mockito.any(DeepCopyTransformation.class))).thenReturn(TempTransitionalBuilderWrapper.wrapper(mock));
+    when(mock.toString()).thenReturn(mock.getClass().getSimpleName() + mockCounter++);
+    return mock;
+  }
+
+
+  /**
+   * Tests that {@link #hashCode()} contract is honoured.
+   */
+  @Test
+  public void testHashCode() {
+    assertEquals(onTest.get().hashCode(), onTest.get().hashCode());
+  }
+
+
+  @SuppressWarnings("unchecked")
+  private List<Object[]> parameterData() {
+    try {
+      return (List<Object[]>) this.getClass().getMethod("data").invoke(this);
+    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException | NoSuchMethodException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+
+  /**
+   * Tests that {@link #equals(Object)} contract is honoured.
+   */
+  @Test
+  public void testEquals() {
+    assertEquals(onTest.get(), onTest.get());
+    assertFalse(onTest.get().equals(null));
+    for (Object[] data : parameterData()) {
+      if (data[0].equals(testName))
+        continue;
+      @SuppressWarnings("unchecked")
+      T other = ((Supplier<T>) data[1]).get();
+      assertNotEquals("Must not equal " + other, other, onTest.get());
+    }
+  }
+
+  /**
+   * Tests that deep copying works correctly.
+   */
+  @Test
+  public void testDeepCopy() {
+    T original = onTest.get();
+    T deepCopy = original.deepCopy(DeepCopyTransformations.noTransformation()).build();
+    assertEquals(deepCopy, original);
+    assertNotSame(deepCopy, original);
+  }
+
+  /**
+   * Compares the toString to the default implementation to make sure it's been defined.
+   */
+  @Test
+  public void testToStringHasBeenDefined() {
+    T t = onTest.get();
+    assertNotEquals(defaultToString(t), t.toString());
+  }
+
+  /**
+   * Tests that the assumption {@link #testToStringHasBeenDefined()} makes
+   * (about the behaviour of the default toString method) is correct.  If this
+   * predicate fails, we won't be correctly testing that toString works.
+   */
+  @Test
+  public void testToStringAssumptionTrue() {
+    Object o = new Object();
+    assertEquals(defaultToString(o), o.toString());
+  }
+
+  private String defaultToString(Object o) {
+    return o.getClass().getName() + "@" + Integer.toHexString(o.hashCode());
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestBracketedExpression.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestBracketedExpression.java
@@ -15,7 +15,7 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.BracketedExpression.bracket;
+import static org.alfasoftware.morf.sql.SqlUtils.bracket;
 import static org.alfasoftware.morf.sql.SqlUtils.literal;
 import static org.alfasoftware.morf.sql.element.MathsField.plus;
 import static org.junit.Assert.assertEquals;
@@ -39,7 +39,7 @@ import org.junit.runners.Parameterized.Parameters;
 @RunWith(Parameterized.class)
 public class TestBracketedExpression extends AbstractAliasedFieldTest<BracketedExpression> {
 
-  public final BracketedExpression onTest = bracket(plus(literal(1), literal(2)));
+  public final BracketedExpression onTest = (BracketedExpression) bracket(plus(literal(1), literal(2)));
 
   @Parameters(name = "{0}")
   public static List<Object[]> data() {

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestBracketedExpression.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestBracketedExpression.java
@@ -16,7 +16,7 @@
 package org.alfasoftware.morf.sql.element;
 
 import static org.alfasoftware.morf.sql.element.BracketedExpression.bracket;
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
 import static org.alfasoftware.morf.sql.element.MathsField.plus;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestBracketedExpression.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestBracketedExpression.java
@@ -15,31 +15,54 @@
 
 package org.alfasoftware.morf.sql.element;
 
+import static org.alfasoftware.morf.sql.element.BracketedExpression.bracket;
 import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.element.MathsField.plus;
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.Collections;
 import java.util.List;
 
+import org.alfasoftware.morf.util.ObjectTreeTraverser;
+import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Unit tests {@link NullFieldLiteral}
+ * Tests {@link BracketedExpression}.
  *
  * @author Copyright (c) Alfa Financial Software 2011
  */
 @RunWith(Parameterized.class)
-public class TestNullFieldLiteral extends AbstractAliasedFieldTest<AliasedField> {
+public class TestBracketedExpression extends AbstractAliasedFieldTest<BracketedExpression> {
+
+  public final BracketedExpression onTest = bracket(plus(literal(1), literal(2)));
 
   @Parameters(name = "{0}")
   public static List<Object[]> data() {
     return Collections.singletonList(
       testCase(
-        "Null",
-        () -> new NullFieldLiteral(),
-        () -> literal(1)
+        "Test 1",
+        () -> bracket(plus(literal(1), literal(2))),
+        () -> bracket(plus(literal(1), literal(3)))
       )
     );
+  }
+
+
+  @Test
+  public void testInnerExpression() {
+    assertEquals(plus(literal(1), literal(2)), onTest.getInnerExpression());
+  }
+
+
+  @Test
+  public void testDrive() {
+    ObjectTreeTraverser.Callback callback = mock(ObjectTreeTraverser.Callback.class);
+    onTest.drive(ObjectTreeTraverser.forCallback(callback));
+    verify(callback).visit(onTest.getInnerExpression());
   }
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCast.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCast.java
@@ -15,39 +15,48 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.SqlUtils.caseStatement;
+import static org.alfasoftware.morf.metadata.DataType.BIG_INTEGER;
+import static org.alfasoftware.morf.metadata.DataType.DECIMAL;
+import static org.alfasoftware.morf.metadata.DataType.INTEGER;
+import static org.alfasoftware.morf.sql.SqlUtils.cast;
 import static org.alfasoftware.morf.sql.SqlUtils.literal;
-import static org.alfasoftware.morf.sql.SqlUtils.when;
 
-import java.util.Collections;
 import java.util.List;
 
-import org.alfasoftware.morf.sql.SqlUtils;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import com.google.common.collect.ImmutableList;
+
 /**
- * Tests {@link CaseStatement}
+ * Tests {@link Cast}.
  *
  * @author Copyright (c) Alfa Financial Software 2011
  */
 @RunWith(Parameterized.class)
-public class TestCaseStatement extends AbstractAliasedFieldTest<CaseStatement> {
+public class TestCast extends AbstractAliasedFieldTest<Cast> {
 
   @Parameters(name = "{0}")
   public static List<Object[]> data() {
-    return Collections.singletonList(
+    return ImmutableList.of(
       testCase(
-        "Test 1",
-        () -> SqlUtils.caseStatement(SqlUtils.when(literal(1).eq(literal(2))).then(literal(3))).otherwise(literal(4)),
-        () -> caseStatement(when(literal(1).eq(literal(2))).then(literal(3))).otherwise(literal(5)),
-        () -> caseStatement(when(literal(1).eq(literal(2))).then(literal(4))).otherwise(literal(4)),
-        () -> caseStatement(when(literal(1).eq(literal(3))).then(literal(3))).otherwise(literal(4)),
-        () -> caseStatement(
-                when(literal(1).eq(literal(2))).then(literal(3)),
-                when(literal(1).eq(literal(2))).then(literal(3))
-              ).otherwise(literal(4))
+        "asString",
+        () -> cast(literal(1)).asString(1),
+        () -> cast(literal(1)).asString(2),
+        () -> cast(literal(1)).asType(INTEGER)
+      ),
+      testCase(
+        "as decimal",
+        () -> cast(literal(1)).asType(DECIMAL),
+        () -> cast(literal(1)).asType(BIG_INTEGER),
+        () -> cast(literal(1)).asType(DECIMAL, 1)
+      ),
+      testCase(
+        "13,2",
+        () -> cast(literal(1)).asType(DECIMAL, 13, 2),
+        () -> cast(literal(1)).asType(DECIMAL, 13, 1),
+        () -> cast(literal(1)).asType(DECIMAL, 12, 2)
       )
     );
   }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestConcatenatedField.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestConcatenatedField.java
@@ -15,30 +15,33 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
+import static org.alfasoftware.morf.sql.element.ConcatenatedField.concat;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import com.google.common.collect.ImmutableList;
+
 /**
- * Unit tests {@link NullFieldLiteral}
+ * Tests {@link ConcatenatedField}.
  *
  * @author Copyright (c) Alfa Financial Software 2011
  */
 @RunWith(Parameterized.class)
-public class TestNullFieldLiteral extends AbstractAliasedFieldTest<AliasedField> {
+public class TestConcatenatedField extends AbstractAliasedFieldTest<ConcatenatedField> {
 
   @Parameters(name = "{0}")
   public static List<Object[]> data() {
-    return Collections.singletonList(
+    return ImmutableList.of(
       testCase(
-        "Null",
-        () -> new NullFieldLiteral(),
-        () -> literal(1)
+        "asString",
+        () -> concat(literal(1), literal(2)),
+        () -> concat(literal(1), literal(3)),
+        () -> concat(literal(1), literal(2), literal(3))
       )
     );
   }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestConcatenatedField.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestConcatenatedField.java
@@ -15,8 +15,8 @@
 
 package org.alfasoftware.morf.sql.element;
 
+import static org.alfasoftware.morf.sql.SqlUtils.concat;
 import static org.alfasoftware.morf.sql.SqlUtils.literal;
-import static org.alfasoftware.morf.sql.element.ConcatenatedField.concat;
 
 import java.util.List;
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestConcatenatedFieldDetail.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestConcatenatedFieldDetail.java
@@ -15,8 +15,8 @@
 
 package org.alfasoftware.morf.sql.element;
 
+import static org.alfasoftware.morf.sql.SqlUtils.concat;
 import static org.alfasoftware.morf.sql.SqlUtils.literal;
-import static org.alfasoftware.morf.sql.element.ConcatenatedField.concat;
 
 import org.junit.Test;
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestConcatenatedFieldDetail.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestConcatenatedFieldDetail.java
@@ -15,31 +15,20 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
+import static org.alfasoftware.morf.sql.element.ConcatenatedField.concat;
 
-import java.util.Collections;
-import java.util.List;
-
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
+import org.junit.Test;
 
 /**
- * Unit tests {@link NullFieldLiteral}
+ * Tests {@link ConcatenatedField}.
  *
  * @author Copyright (c) Alfa Financial Software 2011
  */
-@RunWith(Parameterized.class)
-public class TestNullFieldLiteral extends AbstractAliasedFieldTest<AliasedField> {
+public class TestConcatenatedFieldDetail {
 
-  @Parameters(name = "{0}")
-  public static List<Object[]> data() {
-    return Collections.singletonList(
-      testCase(
-        "Null",
-        () -> new NullFieldLiteral(),
-        () -> literal(1)
-      )
-    );
+  @Test(expected = IllegalArgumentException.class)
+  public void testRequiresAtLeastOneArgument() {
+    concat(literal(1));
   }
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCriterion.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCriterion.java
@@ -1,0 +1,69 @@
+/* Copyright 2017 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.alfasoftware.morf.sql.element;
+
+import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.alfasoftware.morf.sql.SelectStatement;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * Tests for {@link Criterion}.
+ *
+ * @author Copyright (c) Alfa Financial Software 2017
+ */
+@RunWith(Parameterized.class)
+public class TestCriterion extends AbstractDeepCopyableTest<Criterion> {
+
+  @Parameters(name = "{0}")
+  public static List<Object[]> data() {
+    Criterion mock1 = mockOf(Criterion.class);
+    Criterion mock2 = mockOf(Criterion.class);
+    Criterion mock3 = mockOf(Criterion.class);
+    SelectStatement selectStatement1 = mockOf(SelectStatement.class);
+    when(selectStatement1.getFields()).thenReturn(ImmutableList.of(literal('A')));
+    SelectStatement selectStatement2 = mockOf(SelectStatement.class);
+    when(selectStatement2.getFields()).thenReturn(ImmutableList.of(literal('A')));
+
+    return Arrays.asList(
+      testCase("eq 1", () -> Criterion.eq(literal(1), literal(2))),
+      testCase("eq 2", () -> Criterion.eq(literal(1), literal(3))),
+      testCase("and 1", () -> Criterion.and(mock1, mock2)),
+      testCase("and 2", () -> Criterion.and(mock1, mock3)),
+      testCase("and 3", () -> Criterion.and(mock1, mock2, mock3)),
+      testCase("exists 1", () -> Criterion.exists(selectStatement1)),
+      testCase("exists 2", () -> Criterion.exists(selectStatement2)),
+      testCase("greaterThanInteger 1", () -> Criterion.greaterThan(literal(1), 1)),
+      testCase("greaterThanInteger 2", () -> Criterion.greaterThan(literal(1), 2)),
+      testCase("greaterThanLiteral 1", () -> Criterion.greaterThan(literal(1), literal(2))),
+      testCase("greaterThanLiteral 2", () -> Criterion.greaterThan(literal(1), literal(3))),
+      testCase("isNull 1", () -> Criterion.isNull(literal(1))),
+      testCase("isNull 2", () -> Criterion.isNull(literal(2))),
+      testCase("inList 1", () -> Criterion.in(literal(1), literal(2), literal(3))),
+      testCase("inList 2", () -> Criterion.in(literal(1), literal(2), literal(4))),
+      testCase("inSelect 1", () -> Criterion.in(literal(1), selectStatement1)),
+      testCase("inSelect 2", () -> Criterion.in(literal(1), selectStatement2))
+    );
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCriterion.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCriterion.java
@@ -15,7 +15,7 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
 import static org.mockito.Mockito.when;
 
 import java.util.Arrays;

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCriterionDeepCopyAndEquals.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCriterionDeepCopyAndEquals.java
@@ -29,12 +29,12 @@ import org.junit.runners.Parameterized.Parameters;
 import com.google.common.collect.ImmutableList;
 
 /**
- * Tests for {@link Criterion}.
+ * Tests for {@link Criterion}'s implementation of deep copy and equals contracts.
  *
  * @author Copyright (c) Alfa Financial Software 2017
  */
 @RunWith(Parameterized.class)
-public class TestCriterion extends AbstractDeepCopyableTest<Criterion> {
+public class TestCriterionDeepCopyAndEquals extends AbstractDeepCopyableTest<Criterion> {
 
   @Parameters(name = "{0}")
   public static List<Object[]> data() {

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCriterionDetail.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestCriterionDetail.java
@@ -1,0 +1,59 @@
+/* Copyright 2017 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.alfasoftware.morf.sql.element;
+
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
+import static org.alfasoftware.morf.sql.element.Criterion.and;
+import static org.alfasoftware.morf.sql.element.Criterion.isNull;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link Criterion}.
+ *
+ * @author Copyright (c) Alfa Financial Software 2017
+ */
+public class TestCriterionDetail {
+
+  /**
+   * We should be able to add criteria if mutability is enabled.
+   */
+  @Test
+  public void testCanMutateCriteriaWhenMutable() {
+    Criterion criterion = and(isNull(literal(1)), isNull(literal(2)));
+    criterion.getCriteria().add(isNull(literal(3)));
+    assertThat(criterion.getCriteria(), hasSize(3));
+
+    Criterion deepCopy = criterion.deepCopy();
+    deepCopy.getCriteria().add(mock(Criterion.class));
+    assertThat(deepCopy.getCriteria(), hasSize(4));
+  }
+
+
+  /**
+   * We should be NOT able to add criteria if mutability is disabled.
+   */
+  @Test(expected = UnsupportedOperationException.class)
+  public void testCannotMutateCriteriaWhenImmutable() {
+    AliasedField.withImmutableBuildersEnabled(() -> {
+      Criterion criterion = Criterion.and(isNull(literal(1)), isNull(literal(2)));
+      criterion.getCriteria().add(isNull(literal(3)));
+    });
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFieldFromSelect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFieldFromSelect.java
@@ -19,16 +19,36 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import org.junit.Test;
+import java.util.List;
 
 import org.alfasoftware.morf.sql.SelectStatement;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * Tests for field from select.
  *
  * @author Copyright (c) Alfa Financial Software 2010
  */
-public class TestFieldFromSelect {
+@RunWith(Parameterized.class)
+public class TestFieldFromSelect extends AbstractAliasedFieldTest<FieldFromSelect> {
+
+  @Parameters(name = "{0}")
+  public static List<Object[]> data() {
+    SelectStatement stmt1 = mockSelectStatement();
+    SelectStatement stmt2 = mockSelectStatement();
+    return ImmutableList.of(
+      testCase(
+        "simple",
+        () -> new FieldFromSelect(stmt1),
+        () -> new FieldFromSelect(stmt2)
+      )
+    );
+  }
 
 
   /**
@@ -53,7 +73,7 @@ public class TestFieldFromSelect {
    * Verify that deep copy works as expected for field from select.
    */
   @Test
-  public void testDeepCopy() {
+  public void testDeepCopyDetail() {
     SelectStatement statementWithTwoFields = new SelectStatement(new FieldReference("agreementNumber")).from(new TableReference("Schedule"))
         .where(Criterion.eq(new FieldReference(new TableReference("Schedule"), "agreementNumber"), "A001003657"));
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFieldFromSelectFirst.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFieldFromSelectFirst.java
@@ -15,31 +15,34 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
-
-import java.util.Collections;
 import java.util.List;
 
+import org.alfasoftware.morf.sql.SelectFirstStatement;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import com.google.common.collect.ImmutableList;
+
 /**
- * Unit tests {@link NullFieldLiteral}
+ * Tests for field from select first.
  *
- * @author Copyright (c) Alfa Financial Software 2011
+ * @author Copyright (c) Alfa Financial Software 2010
  */
 @RunWith(Parameterized.class)
-public class TestNullFieldLiteral extends AbstractAliasedFieldTest<AliasedField> {
+public class TestFieldFromSelectFirst extends AbstractAliasedFieldTest<FieldFromSelectFirst> {
 
   @Parameters(name = "{0}")
   public static List<Object[]> data() {
-    return Collections.singletonList(
+    SelectFirstStatement stmt1 = mockOf(SelectFirstStatement.class);
+    SelectFirstStatement stmt2 = mockOf(SelectFirstStatement.class);
+    return ImmutableList.of(
       testCase(
-        "Null",
-        () -> new NullFieldLiteral(),
-        () -> literal(1)
+        "simple",
+        () -> new FieldFromSelectFirst(stmt1),
+        () -> new FieldFromSelectFirst(stmt2)
       )
     );
   }
+
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFieldLiteral.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFieldLiteral.java
@@ -15,150 +15,92 @@
 
 package org.alfasoftware.morf.sql.element;
 
+import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
 import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;
+import java.util.List;
 
 import org.joda.time.LocalDate;
 import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableList;
 
 /**
  * Tests for field literals
  *
  * @author Copyright (c) Alfa Financial Software 2010
  */
-public class TestFieldLiteral {
+@RunWith(Parameterized.class)
+public class TestFieldLiteral extends AbstractAliasedFieldTest<FieldLiteral> {
 
-
-  /**
-   * Verify that deep copy works as expected for string field literal.
-   */
-  @Test
-  public void testDeepCopyWithString() {
-    FieldLiteral fl = new FieldLiteral("TEST1");
-    fl.as("testName");
-    FieldLiteral flCopy = (FieldLiteral)fl.deepCopy();
-
-    assertEquals("Field literal value matches", fl.getValue(), flCopy.getValue());
-    assertEquals("Field literal data type matches", fl.getDataType(), flCopy.getDataType());
-    assertEquals("Field literal alias matches", fl.getAlias(), flCopy.getAlias());
+  @Parameters(name = "{0}")
+  public static List<Object[]> data() {
+    return ImmutableList.of(
+      testCase(
+          "BigDecimal",
+          () -> literal(new BigDecimal("1234567890123456789.0123456789")),
+          () -> literal(BigDecimal.ZERO),
+          () -> literal(true)
+      ),
+      testCase(
+          "String",
+          () -> literal("1"),
+          () -> literal("0"),
+          () -> literal(true),
+          () -> literal(1)
+      ),
+      testCase(
+          "Boolean",
+          () -> literal(true),
+          () -> literal(false),
+          () -> literal(1)
+      ),
+      testCase(
+          "Character",
+          () -> literal('a'),
+          () -> literal('b'),
+          () -> literal(1)
+      ),
+      testCase(
+          "Double",
+          () -> literal(1.23D),
+          () -> literal(1)
+      ),
+      testCase(
+          "Long",
+          () -> literal(1L),
+          () -> literal('b')
+      ),
+      testCase(
+          "LocalDate",
+          () -> literal(new LocalDate(2010,1,2)),
+          () -> literal(new LocalDate(2010,1,1)),
+          () -> literal('b')
+      ),
+      testCase(
+          "Integer",
+          () -> literal(1),
+          () -> literal(2),
+          () -> literal('b')
+      )
+    );
   }
 
 
   /**
-   * Verify that deep copy works as expected for Boolean field literal.
+   * Verify that deep copy actually copies the individual properties.
    */
   @Test
-  public void testDeepCopyWithBoolean() {
-    FieldLiteral fl = new FieldLiteral(true);
-    fl.as("testName");
-    FieldLiteral flCopy = (FieldLiteral)fl.deepCopy();
+  public void testDeepCopyDetail() {
+    FieldLiteral f1 = (FieldLiteral) onTestAliased;
+    FieldLiteral flCopy = (FieldLiteral)onTestAliased.deepCopy();
 
-    assertEquals("Field literal value matches", fl.getValue(), flCopy.getValue());
-    assertEquals("Field literal data type matches", fl.getDataType(), flCopy.getDataType());
-    assertEquals("Field literal alias matches", fl.getAlias(), flCopy.getAlias());
+    assertEquals("Field literal value matches", f1.getValue(), flCopy.getValue());
+    assertEquals("Field literal data type matches", f1.getDataType(), flCopy.getDataType());
+    assertEquals("Field literal alias matches", f1.getAlias(), flCopy.getAlias());
   }
-
-
-  /**
-   * Verify that deep copy works as expected for Character field literal.
-   */
-  @Test
-  public void testDeepCopywithCharacter() {
-    FieldLiteral fl = new FieldLiteral('A');
-    fl.as("testName");
-    FieldLiteral flCopy = (FieldLiteral)fl.deepCopy();
-
-    assertEquals("Field literal value matches", fl.getValue(), flCopy.getValue());
-    assertEquals("Field literal data type matches", fl.getDataType(), flCopy.getDataType());
-    assertEquals("Field literal alias matches", fl.getAlias(), flCopy.getAlias());
-  }
-
-
-  /**
-   * Verify that deep copy works as expected for Double field literal.
-   */
-  @Test
-  public void testDeepCopyWithDouble() {
-    FieldLiteral fl = new FieldLiteral(1.23d);
-    fl.as("testName");
-    FieldLiteral flCopy = (FieldLiteral)fl.deepCopy();
-
-    assertEquals("Field literal value matches", fl.getValue(), flCopy.getValue());
-    assertEquals("Field literal data type matches", fl.getDataType(), flCopy.getDataType());
-    assertEquals("Field literal alias matches", fl.getAlias(), flCopy.getAlias());
-  }
-
-
-  /**
-   * Verify that deep copy works as expected for BigDecimal field literal.
-   */
-  @Test
-  public void testDeepCopyWithBigDecimal() {
-    FieldLiteral fl = new FieldLiteral(new BigDecimal("1234567890123456789.0123456789"));
-    fl.as("testName");
-    FieldLiteral flCopy = (FieldLiteral)fl.deepCopy();
-
-    assertEquals("Field literal value matches", fl.getValue(), flCopy.getValue());
-    assertEquals("Field literal value is correct", "1234567890123456789.0123456789", flCopy.getValue());
-    assertEquals("Field literal data type matches", fl.getDataType(), flCopy.getDataType());
-    assertEquals("Field literal alias matches", fl.getAlias(), flCopy.getAlias());
-  }
-
-
-  /**
-   * Verify that deep copy works as expected for Long field literal.
-   */
-  @Test
-  public void testDeepCopyWithLong() {
-    FieldLiteral fl = new FieldLiteral(234234L);
-    fl.as("testName");
-    FieldLiteral flCopy = (FieldLiteral)fl.deepCopy();
-
-    assertEquals("Field literal value matches", fl.getValue(), flCopy.getValue());
-    assertEquals("Field literal data type matches", fl.getDataType(), flCopy.getDataType());
-    assertEquals("Field literal alias matches", fl.getAlias(), flCopy.getAlias());
-  }
-
-
-  /**
-   * Verify that deep copy works as expected for {@link LocalDate} field literal.
-   */
-  @Test
-  public void testDeepCopyWithLocalDate() {
-    FieldLiteral fl = new FieldLiteral(new LocalDate(2010,1,2));
-    fl.as("testName");
-    FieldLiteral flCopy = (FieldLiteral)fl.deepCopy();
-
-    assertEquals("Field literal value matches", fl.getValue(), flCopy.getValue());
-    assertEquals("Field literal data type matches", fl.getDataType(), flCopy.getDataType());
-    assertEquals("Field literal alias matches", fl.getAlias(), flCopy.getAlias());
-  }
-
-
-  /**
-   * Verify that deep copy works as expected for Double field literal.
-   */
-  @Test
-  public void testDeepCopyWithInteger() {
-    FieldLiteral fl = new FieldLiteral(1);
-    fl.as("testName");
-    FieldLiteral flCopy = (FieldLiteral)fl.deepCopy();
-
-    assertEquals("Field literal value matches", fl.getValue(), flCopy.getValue());
-    assertEquals("Field literal data type matches", fl.getDataType(), flCopy.getDataType());
-    assertEquals("Field literal alias matches", fl.getAlias(), flCopy.getAlias());
-  }
-
-  /**
-   * Confirms that the implied name returns the alias
-   */
-  @Test
-  public void testImpliedName() {
-    FieldLiteral fl = new FieldLiteral(1);
-    assertEquals("Field literal implied name correctly initialised", fl.getImpliedName(), "");
-    fl.as("testName");
-    assertEquals("Field literal implied name matches alias", fl.getImpliedName(), "testName");
-  }
-
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFieldLiteral.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFieldLiteral.java
@@ -15,7 +15,7 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
 import static org.junit.Assert.assertEquals;
 
 import java.math.BigDecimal;

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFunction.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFunction.java
@@ -15,11 +15,15 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertTrue;
+import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
 
-import org.junit.Test;
+import java.util.List;
+
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+import com.google.common.collect.ImmutableList;
 
 
 /**
@@ -27,249 +31,31 @@ import org.junit.Test;
  *
  * @author Copyright (c) Alfa Financial Software 2010
  */
-public class TestFunction {
+@RunWith(Parameterized.class)
+public class TestFunction extends AbstractAliasedFieldTest<Function> {
 
-
-  /**
-   * Verify that deep copy works as expected for functions without arguments.
-   */
-  @Test
-  public void testDeepCopyNoArgs() {
-    Function func = Function.count();
-    func.as("testName");
-    Function funcCopy = (Function)func.deepCopy();
-
-    assertEquals("Function type matches", func.getType(), funcCopy.getType());
-    assertEquals("Function type matches", func.getAlias(), funcCopy.getAlias());
+  @Parameters(name = "{0}")
+  public static List<Object[]> data() {
+    return ImmutableList.of(
+        testCase(
+          "Count",
+          () -> Function.count(),
+          () -> Function.now()
+        ),
+        testCase(
+          "Average",
+          () -> Function.average(literal(1)),
+          () -> Function.average(literal(2)),
+          () -> Function.sum(literal(1))
+        ),
+        testCase(
+          "Coalesce",
+          () -> Function.coalesce(literal(1), literal(1)),
+          () -> Function.coalesce(literal(2), literal(1)),
+          () -> Function.coalesce(literal(1)),
+          () -> Function.coalesce(literal(2)),
+          () -> Function.coalesce(literal(1), literal(1), literal(1))
+        )
+    );
   }
-
-
-  /**
-   * Verify that deep copy works as expected for functions with arguments.
-   */
-  @Test
-  public void testDeepCopyOneArg() {
-    Function func = Function.max(new FieldReference("startDate"));
-    func.as("testName");
-    Function funcCopy = (Function)func.deepCopy();
-
-    assertEquals("Function type matches", func.getType(), funcCopy.getType());
-    assertEquals("Function type matches", func.getAlias(), funcCopy.getAlias());
-
-    assertNotNull("Copy should have arguments", funcCopy.getArguments());
-    assertEquals("Copy should have right number of arguments", 1, funcCopy.getArguments().size());
-
-    assertTrue("Copies should be different objects", func.getArguments().get(0) != funcCopy.getArguments().get(0));
-
-    assertEquals("Fields in copy should be the same", func.getArguments().get(0).getAlias(), funcCopy.getArguments().get(0).getAlias());
-  }
-
-
-  /**
-   * Tests the indirect usage of the maximum function
-   */
-  @Test
-  public void testMax() {
-    Function func = Function.max(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type MAX", FunctionType.MAX, func.getType());
-    assertNotNull("Function should have arguments", func.getArguments());
-    assertEquals("Function should have two arguments", 1, func.getArguments().size());
-    AliasedField firstArgument = func.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
-  }
-
-
-  /**
-   * Tests the indirect usage of the maximum function
-   */
-  @Test
-  public void testMin() {
-    Function func = Function.min(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type MIN", FunctionType.MIN, func.getType());
-    assertNotNull("Function should have arguments", func.getArguments());
-    assertEquals("Function should have two arguments", 1, func.getArguments().size());
-    AliasedField firstArgument = func.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
-  }
-
-
-  /**
-   * Tests the indirect usage of the sum function
-   */
-  @Test
-  public void testSum() {
-    Function func = Function.sum(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type SUM", FunctionType.SUM, func.getType());
-    assertNotNull("Function should have arguments", func.getArguments());
-    assertEquals("Function should have one argument", 1, func.getArguments().size());
-    AliasedField firstArgument = func.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
-  }
-
-
-  /**
-   * Tests the indirect usage of the length function
-   */
-  @Test
-  public void testLength() {
-    Function func = Function.length(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type LENGTH", FunctionType.LENGTH, func.getType());
-    assertNotNull("Function should have arguments", func.getArguments());
-    assertEquals("Function should have one argument", 1, func.getArguments().size());
-    AliasedField firstArgument = func.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
-  }
-
-
-  /**
-   * Tests indirect usage of the substring function
-   */
-  @Test
-  public void testSubstring() {
-    Function func = Function.substring(new FieldReference("agreementNumber"), new FieldLiteral(2), new FieldLiteral(3));
-
-    assertEquals("Function should be of type SUBSTRING", FunctionType.SUBSTRING, func.getType());
-    assertNotNull("Function should have arguments", func.getArguments());
-    assertEquals("Function should have three arguments", 3, func.getArguments().size());
-    AliasedField firstArgument = func.getArguments().get(0);
-    AliasedField secondArgument = func.getArguments().get(1);
-    AliasedField thirdArgument = func.getArguments().get(2);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
-    assertTrue("Second argument should be a field literal", secondArgument instanceof FieldLiteral);
-    assertEquals("Second argument should have correct value", "2", ((FieldLiteral)secondArgument).getValue());
-    assertTrue("Third argument should be a field literal", thirdArgument instanceof FieldLiteral);
-    assertEquals("Third argument should have correct value", "3", ((FieldLiteral)thirdArgument).getValue());
-  }
-
-  /**
-   * Tests indirect usage of the YYYYMMDDToDate function
-   */
-  @Test
-  public void testYYYYMMDDToDate() {
-    Function func = Function.yyyymmddToDate(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type YYYYMMDDToDate", FunctionType.YYYYMMDD_TO_DATE, func.getType());
-    assertNotNull("Function should have arguments", func.getArguments());
-    assertEquals("Function should have one argument", 1, func.getArguments().size());
-    AliasedField firstArgument = func.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
-  }
-
-
-  /**
-   * Tests indirect usage of the leftTrim function
-   */
-  @Test
-  public void testLeftTrim() {
-    Function function = Function.leftTrim(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type Left Trim", FunctionType.LEFT_TRIM, function.getType());
-    assertNotNull("Function should have arguments", function.getArguments());
-    assertEquals("Function should have one argument", 1, function.getArguments().size());
-    AliasedField firstArgument = function.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
-  }
-
-
-  /**
-   * Tests indirect usage of the rightTrim function
-   */
-  @Test
-  public void testRightTrim() {
-    Function function = Function.rightTrim(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type Right Trim", FunctionType.RIGHT_TRIM, function.getType());
-    assertNotNull("Function should have arguments", function.getArguments());
-    assertEquals("Function should have one argument", 1, function.getArguments().size());
-    AliasedField firstArgument = function.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
-  }
-
-
-  /**
-   * Tests the indirect usage of leftPad
-   */
-  @Test
-  public void testLeftPad() {
-    Function function = Function.leftPad(new FieldReference("invoiceNumber"), new FieldLiteral(10), new FieldLiteral('j'));
-
-    assertEquals("Function must be of type LEFT_PAD", FunctionType.LEFT_PAD, function.getType());
-    assertEquals("Function should have 3 arguments", 3, function.getArguments().size());
-  }
-
-
-  /**
-   * Tests the indirect usage of leftPad
-   */
-  @Test
-  public void testLeftPadConvenientMethod() {
-    Function function = Function.leftPad(new FieldReference("invoiceNumber"), 10, "j");
-
-    assertEquals("Function must be of type LEFT_PAD", FunctionType.LEFT_PAD, function.getType());
-    assertEquals("Function should have 3 arguments", 3, function.getArguments().size());
-  }
-  
-  
-  /**
-   * Tests indirect usage of the mod function
-   */
-  @Test
-  public void testMod() {
-    Function function = Function.mod(new FieldReference("scheduleNumber"), new FieldLiteral(2));
-
-    assertEquals("Function should be of type MOD", FunctionType.MOD, function.getType());
-    assertNotNull("Function should have arguments", function.getArguments());
-    assertEquals("Function should have two argument", 2, function.getArguments().size());
-    AliasedField firstArgument = function.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "scheduleNumber", ((FieldReference)firstArgument).getName());
-    AliasedField secondArgument = function.getArguments().get(1);
-    assertTrue("Second argument should be a field literal", secondArgument instanceof FieldLiteral);
-    assertEquals("Second argument should have correct value", "2", ((FieldLiteral)secondArgument).getValue());
-  }
-
-
-  /**
-   * Tests indirect usage of the <code>lowerCase</code> function
-   */
-  @Test
-  public void testLowerCase() {
-    Function function = Function.lowerCase(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type LOWER", FunctionType.LOWER, function.getType());
-    assertNotNull("Function should have arguments", function.getArguments());
-    assertEquals("Function should have one argument", 1, function.getArguments().size());
-    AliasedField firstArgument = function.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference) firstArgument).getName());
-  }
-
-
-  /**
-   * Tests indirect usage of the <code>upperCase</code> function
-   */
-  @Test
-  public void testUpperCase() {
-    Function function = Function.upperCase(new FieldReference("agreementNumber"));
-
-    assertEquals("Function should be of type UPPER", FunctionType.UPPER, function.getType());
-    assertNotNull("Function should have arguments", function.getArguments());
-    assertEquals("Function should have one argument", 1, function.getArguments().size());
-    AliasedField firstArgument = function.getArguments().get(0);
-    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
-    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference) firstArgument).getName());
-  }
-
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFunction.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFunction.java
@@ -15,7 +15,7 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
 
 import java.util.List;
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFunctionDetail.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFunctionDetail.java
@@ -1,0 +1,256 @@
+/* Copyright 2017 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.alfasoftware.morf.sql.element;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+
+/**
+ * Tests for Function
+ *
+ * @author Copyright (c) Alfa Financial Software 2010
+ */
+public class TestFunctionDetail {
+
+  /**
+   * Verify that deep copy works as expected for functions with arguments.
+   */
+  @Test
+  public void testDeepCopyOneArg() {
+    Function func = Function.max(new FieldReference("startDate"));
+    func.as("testName");
+    Function funcCopy = (Function)func.deepCopy();
+
+    assertEquals("Function type matches", func.getType(), funcCopy.getType());
+    assertEquals("Function type matches", func.getAlias(), funcCopy.getAlias());
+
+    assertNotNull("Copy should have arguments", funcCopy.getArguments());
+    assertEquals("Copy should have right number of arguments", 1, funcCopy.getArguments().size());
+    assertEquals("Fields in copy should be the same", func.getArguments().get(0).getAlias(), funcCopy.getArguments().get(0).getAlias());
+  }
+
+
+  /**
+   * Tests the indirect usage of the maximum function
+   */
+  @Test
+  public void testMax() {
+    Function func = Function.max(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type MAX", FunctionType.MAX, func.getType());
+    assertNotNull("Function should have arguments", func.getArguments());
+    assertEquals("Function should have two arguments", 1, func.getArguments().size());
+    AliasedField firstArgument = func.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
+  }
+
+
+  /**
+   * Tests the indirect usage of the maximum function
+   */
+  @Test
+  public void testMin() {
+    Function func = Function.min(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type MIN", FunctionType.MIN, func.getType());
+    assertNotNull("Function should have arguments", func.getArguments());
+    assertEquals("Function should have two arguments", 1, func.getArguments().size());
+    AliasedField firstArgument = func.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
+  }
+
+
+  /**
+   * Tests the indirect usage of the sum function
+   */
+  @Test
+  public void testSum() {
+    Function func = Function.sum(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type SUM", FunctionType.SUM, func.getType());
+    assertNotNull("Function should have arguments", func.getArguments());
+    assertEquals("Function should have one argument", 1, func.getArguments().size());
+    AliasedField firstArgument = func.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
+  }
+
+
+  /**
+   * Tests the indirect usage of the length function
+   */
+  @Test
+  public void testLength() {
+    Function func = Function.length(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type LENGTH", FunctionType.LENGTH, func.getType());
+    assertNotNull("Function should have arguments", func.getArguments());
+    assertEquals("Function should have one argument", 1, func.getArguments().size());
+    AliasedField firstArgument = func.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
+  }
+
+
+  /**
+   * Tests indirect usage of the substring function
+   */
+  @Test
+  public void testSubstring() {
+    Function func = Function.substring(new FieldReference("agreementNumber"), new FieldLiteral(2), new FieldLiteral(3));
+
+    assertEquals("Function should be of type SUBSTRING", FunctionType.SUBSTRING, func.getType());
+    assertNotNull("Function should have arguments", func.getArguments());
+    assertEquals("Function should have three arguments", 3, func.getArguments().size());
+    AliasedField firstArgument = func.getArguments().get(0);
+    AliasedField secondArgument = func.getArguments().get(1);
+    AliasedField thirdArgument = func.getArguments().get(2);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
+    assertTrue("Second argument should be a field literal", secondArgument instanceof FieldLiteral);
+    assertEquals("Second argument should have correct value", "2", ((FieldLiteral)secondArgument).getValue());
+    assertTrue("Third argument should be a field literal", thirdArgument instanceof FieldLiteral);
+    assertEquals("Third argument should have correct value", "3", ((FieldLiteral)thirdArgument).getValue());
+  }
+
+  /**
+   * Tests indirect usage of the YYYYMMDDToDate function
+   */
+  @Test
+  public void testYYYYMMDDToDate() {
+    Function func = Function.yyyymmddToDate(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type YYYYMMDDToDate", FunctionType.YYYYMMDD_TO_DATE, func.getType());
+    assertNotNull("Function should have arguments", func.getArguments());
+    assertEquals("Function should have one argument", 1, func.getArguments().size());
+    AliasedField firstArgument = func.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
+  }
+
+
+  /**
+   * Tests indirect usage of the leftTrim function
+   */
+  @Test
+  public void testLeftTrim() {
+    Function function = Function.leftTrim(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type Left Trim", FunctionType.LEFT_TRIM, function.getType());
+    assertNotNull("Function should have arguments", function.getArguments());
+    assertEquals("Function should have one argument", 1, function.getArguments().size());
+    AliasedField firstArgument = function.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
+  }
+
+
+  /**
+   * Tests indirect usage of the rightTrim function
+   */
+  @Test
+  public void testRightTrim() {
+    Function function = Function.rightTrim(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type Right Trim", FunctionType.RIGHT_TRIM, function.getType());
+    assertNotNull("Function should have arguments", function.getArguments());
+    assertEquals("Function should have one argument", 1, function.getArguments().size());
+    AliasedField firstArgument = function.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference)firstArgument).getName());
+  }
+
+
+  /**
+   * Tests the indirect usage of leftPad
+   */
+  @Test
+  public void testLeftPad() {
+    Function function = Function.leftPad(new FieldReference("invoiceNumber"), new FieldLiteral(10), new FieldLiteral('j'));
+
+    assertEquals("Function must be of type LEFT_PAD", FunctionType.LEFT_PAD, function.getType());
+    assertEquals("Function should have 3 arguments", 3, function.getArguments().size());
+  }
+
+
+  /**
+   * Tests the indirect usage of leftPad
+   */
+  @Test
+  public void testLeftPadConvenientMethod() {
+    Function function = Function.leftPad(new FieldReference("invoiceNumber"), 10, "j");
+
+    assertEquals("Function must be of type LEFT_PAD", FunctionType.LEFT_PAD, function.getType());
+    assertEquals("Function should have 3 arguments", 3, function.getArguments().size());
+  }
+
+
+  /**
+   * Tests indirect usage of the mod function
+   */
+  @Test
+  public void testMod() {
+    Function function = Function.mod(new FieldReference("scheduleNumber"), new FieldLiteral(2));
+
+    assertEquals("Function should be of type MOD", FunctionType.MOD, function.getType());
+    assertNotNull("Function should have arguments", function.getArguments());
+    assertEquals("Function should have two argument", 2, function.getArguments().size());
+    AliasedField firstArgument = function.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "scheduleNumber", ((FieldReference)firstArgument).getName());
+    AliasedField secondArgument = function.getArguments().get(1);
+    assertTrue("Second argument should be a field literal", secondArgument instanceof FieldLiteral);
+    assertEquals("Second argument should have correct value", "2", ((FieldLiteral)secondArgument).getValue());
+  }
+
+
+  /**
+   * Tests indirect usage of the <code>lowerCase</code> function
+   */
+  @Test
+  public void testLowerCase() {
+    Function function = Function.lowerCase(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type LOWER", FunctionType.LOWER, function.getType());
+    assertNotNull("Function should have arguments", function.getArguments());
+    assertEquals("Function should have one argument", 1, function.getArguments().size());
+    AliasedField firstArgument = function.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference) firstArgument).getName());
+  }
+
+
+  /**
+   * Tests indirect usage of the <code>upperCase</code> function
+   */
+  @Test
+  public void testUpperCase() {
+    Function function = Function.upperCase(new FieldReference("agreementNumber"));
+
+    assertEquals("Function should be of type UPPER", FunctionType.UPPER, function.getType());
+    assertNotNull("Function should have arguments", function.getArguments());
+    assertEquals("Function should have one argument", 1, function.getArguments().size());
+    AliasedField firstArgument = function.getArguments().get(0);
+    assertTrue("First argument should be a field reference", firstArgument instanceof FieldReference);
+    assertEquals("First argument should have correct name", "agreementNumber", ((FieldReference) firstArgument).getName());
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestJoin.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestJoin.java
@@ -1,0 +1,58 @@
+/* Copyright 2017 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.alfasoftware.morf.sql.element;
+
+import java.util.Arrays;
+import java.util.List;
+
+import org.alfasoftware.morf.sql.SelectStatement;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+
+/**
+ * Tests for {@link Join}.
+ *
+ * @author Copyright (c) Alfa Financial Software 2017
+ */
+@RunWith(Parameterized.class)
+public class TestJoin extends AbstractDeepCopyableTest<Join> {
+
+  @Parameters(name = "{0}")
+  public static List<Object[]> data() {
+    TableReference table1 = mockOf(TableReference.class);
+    TableReference table2 = mockOf(TableReference.class);
+    Criterion criterion1 = mockOf(Criterion.class);
+    Criterion criterion2 = mockOf(Criterion.class);
+    SelectStatement select1 = mockOf(SelectStatement.class);
+    SelectStatement select2 = mockOf(SelectStatement.class);
+
+    return Arrays.asList(
+      testCase("inner table 1", () -> new Join(JoinType.INNER_JOIN, table1, criterion1)),
+      testCase("inner table 2", () -> new Join(JoinType.INNER_JOIN, table1, criterion2)),
+      testCase("inner table 3", () -> new Join(JoinType.INNER_JOIN, table2, criterion1)),
+      testCase("left table 1", () -> new Join(JoinType.LEFT_OUTER_JOIN, table1, criterion1)),
+      testCase("left table 2", () -> new Join(JoinType.LEFT_OUTER_JOIN, table1, criterion2)),
+      testCase("left table 3", () -> new Join(JoinType.LEFT_OUTER_JOIN, table2, criterion1)),
+      testCase("inner select 1", () -> new Join(JoinType.INNER_JOIN, select1, criterion1)),
+      testCase("inner select 2", () -> new Join(JoinType.INNER_JOIN, select1, criterion2)),
+      testCase("inner select 3", () -> new Join(JoinType.INNER_JOIN, select2, criterion1)),
+      testCase("left select 1", () -> new Join(JoinType.LEFT_OUTER_JOIN, select1, criterion1)),
+      testCase("left select 2", () -> new Join(JoinType.LEFT_OUTER_JOIN, select1, criterion2)),
+      testCase("left select 3", () -> new Join(JoinType.LEFT_OUTER_JOIN, select2, criterion1))
+    );
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestMathsField.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestMathsField.java
@@ -17,28 +17,30 @@ package org.alfasoftware.morf.sql.element;
 
 import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
 
-import java.util.Collections;
 import java.util.List;
 
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
+import com.google.common.collect.ImmutableList;
+
 /**
- * Unit tests {@link NullFieldLiteral}
+ * Tests {@link MathsField}.
  *
  * @author Copyright (c) Alfa Financial Software 2011
  */
 @RunWith(Parameterized.class)
-public class TestNullFieldLiteral extends AbstractAliasedFieldTest<AliasedField> {
+public class TestMathsField extends AbstractAliasedFieldTest<MathsField> {
 
   @Parameters(name = "{0}")
   public static List<Object[]> data() {
-    return Collections.singletonList(
+    return ImmutableList.of(
       testCase(
-        "Null",
-        () -> new NullFieldLiteral(),
-        () -> literal(1)
+        "Test 1",
+        () -> MathsField.plus(literal(1), literal(2)),
+        () -> MathsField.multiply(literal(1), literal(2)),
+        () -> MathsField.plus(literal(1), literal(3))
       )
     );
   }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestMathsField.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestMathsField.java
@@ -15,7 +15,7 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
 
 import java.util.List;
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestNullFieldLiteral.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestNullFieldLiteral.java
@@ -15,7 +15,7 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
 
 import java.util.Collections;
 import java.util.List;

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestTableReference.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestTableReference.java
@@ -1,0 +1,92 @@
+/* Copyright 2017 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.alfasoftware.morf.sql.element;
+
+import static org.alfasoftware.morf.sql.SqlUtils.tableRef;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertSame;
+
+import org.junit.Test;
+
+/**
+ * Tests for {@link TableReference}.
+ *
+ * @author Copyright (c) Alfa Financial Software 2017
+ */
+public class TestTableReference {
+
+  private final TableReference onTest = tableRef("A");
+  private final TableReference isEqual = tableRef("A");
+  private final TableReference notEqualDueToSchema = new TableReference("Schema", "A");
+  private final TableReference notEqualDueToName = tableRef("B");
+  private final TableReference notEqualDueToAlias = tableRef("A").as("X");
+
+  private final TableReference onTestAliased = new TableReference("Schema", "A").as("X");
+  private final TableReference isEqualAliased = new TableReference("Schema", "A").as("X");
+  private final TableReference differentSchema = new TableReference("Schema2", "A").as("X");
+  private final TableReference differentName = new TableReference("Schema", "B").as("X");
+  private final TableReference differentAlias = new TableReference("Schema", "A").as("Y");
+
+  @Test
+  public void testHashCode() {
+    assertEquals(isEqual.hashCode(), onTest.hashCode());
+    assertEquals(isEqualAliased.hashCode(), onTestAliased.hashCode());
+  }
+
+  @Test
+  public void testEquals() {
+    assertEquals(isEqual, onTest);
+    assertFalse(onTest.equals(null));
+    assertNotEquals(notEqualDueToSchema, onTest);
+    assertNotEquals(notEqualDueToName, onTest);
+    assertNotEquals(notEqualDueToAlias, onTest);
+
+    assertEquals(isEqualAliased, onTestAliased);
+    assertNotEquals(differentSchema, onTestAliased);
+    assertNotEquals(differentName, onTestAliased);
+    assertNotEquals(differentAlias, onTestAliased);
+  }
+
+  @Test
+  public void testAliasImmutability() {
+    AliasedField.withImmutableBuildersEnabled(() -> {
+      assertEquals(isEqual.as("A"), onTest.as("A"));
+      assertEquals(isEqual.as("B").as("A"), onTest.as("A"));
+      assertNotEquals(isEqual.as("A"), onTest.as("B"));
+      assertNotSame(onTest, onTest.as("A"));
+    });
+
+    // Should get the same object with immutable builders off
+    assertSame(onTest, onTest.as("A"));
+  }
+
+  @Test
+  public void testDeepCopy() {
+    TableReference deepCopy = onTest.deepCopy();
+    assertEquals(deepCopy, onTest);
+    assertNotSame(deepCopy, onTest);
+  }
+
+  @Test
+  public void testDeepCopyAliased() {
+    TableReference deepCopy = onTestAliased.deepCopy();
+    assertEquals(deepCopy, onTestAliased);
+    assertNotSame(deepCopy, onTestAliased);
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWhenCondition.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWhenCondition.java
@@ -17,7 +17,7 @@ package org.alfasoftware.morf.sql.element;
 
 import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
 
-import java.util.Collections;
+import java.util.Arrays;
 import java.util.List;
 
 import org.junit.runner.RunWith;
@@ -25,21 +25,21 @@ import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameters;
 
 /**
- * Unit tests {@link NullFieldLiteral}
+ * Tests for {@link WhenCondition}.
  *
- * @author Copyright (c) Alfa Financial Software 2011
+ * @author Copyright (c) Alfa Financial Software 2017
  */
 @RunWith(Parameterized.class)
-public class TestNullFieldLiteral extends AbstractAliasedFieldTest<AliasedField> {
+public class TestWhenCondition extends AbstractDeepCopyableTest<WhenCondition> {
 
   @Parameters(name = "{0}")
   public static List<Object[]> data() {
-    return Collections.singletonList(
-      testCase(
-        "Null",
-        () -> new NullFieldLiteral(),
-        () -> literal(1)
-      )
+    Criterion criterion1 = mockOf(Criterion.class);
+    Criterion criterion2 = mockOf(Criterion.class);
+    return Arrays.asList(
+      testCase("1", () -> new WhenCondition(criterion1, literal(1))),
+      testCase("2", () -> new WhenCondition(criterion1, literal(2))),
+      testCase("3", () -> new WhenCondition(criterion2, literal(1)))
     );
   }
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWhenCondition.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWhenCondition.java
@@ -15,7 +15,7 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
 
 import java.util.Arrays;
 import java.util.List;

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWindowFunctions.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWindowFunctions.java
@@ -15,138 +15,37 @@
 
 package org.alfasoftware.morf.sql.element;
 
-import static org.alfasoftware.morf.sql.SqlUtils.field;
-import static org.alfasoftware.morf.sql.SqlUtils.tableRef;
-import static org.alfasoftware.morf.sql.element.Function.floor;
+import static org.alfasoftware.morf.sql.SqlUtils.windowFunction;
+import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
 import static org.alfasoftware.morf.sql.element.Function.sum;
-import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotSame;
-import static org.junit.Assert.assertThat;
 
-import org.alfasoftware.morf.sql.SqlUtils;
-import org.hamcrest.Description;
-import org.hamcrest.Matcher;
-import org.hamcrest.TypeSafeMatcher;
-import org.junit.Test;
+import java.util.Collections;
+import java.util.List;
 
-import com.google.common.collect.Lists;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
 
 /**
  * Tests the WindowFunction DSL
  *
  * @author Copyright (c) Alfa Financial Software 2017
  */
-public class TestWindowFunctions {
+@RunWith(Parameterized.class)
+public class TestWindowFunctions extends AbstractAliasedFieldTest<WindowFunction> {
 
-  private final FieldReference field1 = tableRef("table1").field("field1");
-  private final FieldReference field2Asc = tableRef("table1").field("field2").asc();
-  private final FieldReference field3Desc = field("field3").desc();
-  private final FieldReference field4NoOrder = tableRef("table1").field("field4");
-
-
-  /**
-   * Test exception is thrown when an unsupported function type is used.
-   */
-  @Test(expected = IllegalArgumentException.class)
-  public void testInvalidFunctionException() {
-    SqlUtils.windowFunction(floor(field1)).build();
-  }
-
-
-  /**
-   * Test exception is thrown when an empty list of fields is passed as a partition by list.
-   */
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullPartitionByException() {
-    SqlUtils.windowFunction(sum(field1)).partitionBy().build();
-  }
-
-
-  /**
-   * Test exception is thrown when an empty list of fields is passed as a order by list.
-   */
-  @Test(expected = IllegalArgumentException.class)
-  public void testNullOrderByException() {
-    SqlUtils.windowFunction(sum(field1)).orderBy().build();
-  }
-
-
-  /**
-   * Test deep copying does not copy instances.
-   */
-  @Test
-  public void testDeepCopy() {
-    WindowFunction windowFunction = (WindowFunction) SqlUtils.windowFunction(sum(field1))
-                                    .partitionBy(field2Asc)
-                                    .orderBy(field3Desc)
-                                    .build()
-                                    .as("windowFunction1");
-
-    WindowFunction copy = (WindowFunction) windowFunction.deepCopy();
-
-    assertNotSame(copy.getOrderBys(),windowFunction.getOrderBys());
-    assertNotSame(copy.getPartitionBys(),windowFunction.getPartitionBys());
-    assertEquals(copy.getOrderBys(),windowFunction.getOrderBys());
-    assertEquals(copy.getPartitionBys(),windowFunction.getPartitionBys());
-    assertEquals(copy.getAlias(),windowFunction.getAlias());
-  }
-
-
-  /**
-   * Test the builder pattern preserves previous calls.
-   */
-  @Test
-  public void testMultipleBuilderCalls() {
-    WindowFunction windowFunction = (WindowFunction) SqlUtils.windowFunction(sum(field1))
-                                    .partitionBy(field2Asc)
-                                    .partitionBy(Lists.newArrayList(field3Desc))
-                                    .orderBy(field3Desc)
-                                    .orderBy(Lists.newArrayList(field4NoOrder))
-                                    .build();
-
-
-    assertThat(windowFunction.getOrderBys(),hasSize(2));
-    assertThat(windowFunction.getPartitionBys(),hasSize(2));
-
-  }
-
-
-  /**
-   * Tests order by direction defaulting.
-   */
-  @SuppressWarnings("unchecked")
-  @Test
-  public void testOrderDefaulting() {
-
-    field4NoOrder.setDirection(Direction.NONE);
-
-    WindowFunction windowFunction = (WindowFunction) SqlUtils.windowFunction(sum(field1))
-                                    .orderBy(field2Asc,field3Desc,field4NoOrder)
-                                    .build();
-
-
-    assertThat(windowFunction.getOrderBys(),hasSize(3));
-    assertThat(windowFunction.getOrderBys(),contains(fieldReferenceWithNameAndDirection("field2",Direction.ASCENDING),
-                                                    fieldReferenceWithNameAndDirection("field3",Direction.DESCENDING),
-                                                    fieldReferenceWithNameAndDirection("field4",Direction.ASCENDING)));
-  }
-
-
-  private Matcher<AliasedField> fieldReferenceWithNameAndDirection(final String name,final Direction direction){
-    return new TypeSafeMatcher<AliasedField>() {
-
-      @Override
-      public void describeTo(Description description) {
-        description.appendText("Name:").appendValue(name).appendText(" Direction:").appendValue(direction);
-      }
-
-
-      @Override
-      protected boolean matchesSafely(AliasedField item) {
-        return item instanceof FieldReference && ((FieldReference) item).getDirection() == direction && name.equals(((FieldReference) item).getName()) ;
-      }
-    };
+  @Parameters(name = "{0}")
+  public static List<Object[]> data() {
+    return Collections.singletonList(
+      testCase(
+        "Full",
+        () -> windowFunction(sum(literal(1))).partitionBy(literal(2)).orderBy(literal(3)).build(),
+        () -> windowFunction(sum(literal(1))).partitionBy(literal(2)).orderBy(literal(4)).build(),
+        () -> windowFunction(sum(literal(1))).partitionBy(literal(3)).orderBy(literal(3)).build(),
+        () -> windowFunction(sum(literal(2))).partitionBy(literal(2)).orderBy(literal(3)).build(),
+        () -> windowFunction(sum(literal(1))).orderBy(literal(3)).build(),
+        () -> windowFunction(sum(literal(1))).partitionBy(literal(2)).build()
+      )
+    );
   }
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWindowFunctions.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWindowFunctions.java
@@ -16,7 +16,7 @@
 package org.alfasoftware.morf.sql.element;
 
 import static org.alfasoftware.morf.sql.SqlUtils.windowFunction;
-import static org.alfasoftware.morf.sql.element.FieldLiteral.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
 import static org.alfasoftware.morf.sql.element.Function.sum;
 
 import java.util.Collections;

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWindowFunctionsDetail.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestWindowFunctionsDetail.java
@@ -1,0 +1,155 @@
+/* Copyright 2017 Alfa Financial Software
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.alfasoftware.morf.sql.element;
+
+import static org.alfasoftware.morf.sql.SqlUtils.field;
+import static org.alfasoftware.morf.sql.SqlUtils.tableRef;
+import static org.alfasoftware.morf.sql.element.Function.floor;
+import static org.alfasoftware.morf.sql.element.Function.sum;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.hasSize;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.junit.Assert.assertThat;
+
+import org.alfasoftware.morf.sql.SqlUtils;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+import org.junit.Test;
+
+import com.google.common.collect.Lists;
+
+/**
+ * Tests the WindowFunction DSL
+ *
+ * @author Copyright (c) Alfa Financial Software 2017
+ */
+public class TestWindowFunctionsDetail {
+
+  private final FieldReference field1 = tableRef("table1").field("field1");
+  private final FieldReference field2Asc = tableRef("table1").field("field2").asc();
+  private final FieldReference field3Desc = field("field3").desc();
+  private final FieldReference field4NoOrder = tableRef("table1").field("field4");
+
+
+  /**
+   * Test exception is thrown when an unsupported function type is used.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testInvalidFunctionException() {
+    SqlUtils.windowFunction(floor(field1)).build();
+  }
+
+
+  /**
+   * Test exception is thrown when an empty list of fields is passed as a partition by list.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullPartitionByException() {
+    SqlUtils.windowFunction(sum(field1)).partitionBy().build();
+  }
+
+
+  /**
+   * Test exception is thrown when an empty list of fields is passed as a order by list.
+   */
+  @Test(expected = IllegalArgumentException.class)
+  public void testNullOrderByException() {
+    SqlUtils.windowFunction(sum(field1)).orderBy().build();
+  }
+
+
+  /**
+   * Test deep copying does not copy instances, copies are equal.
+   */
+  @Test
+  public void testDeepCopyDetailed() {
+    WindowFunction windowFunction = (WindowFunction) SqlUtils.windowFunction(sum(field1))
+                                    .partitionBy(field2Asc)
+                                    .orderBy(field3Desc)
+                                    .build()
+                                    .as("windowFunction1");
+
+    WindowFunction copy = (WindowFunction) windowFunction.deepCopy();
+
+    assertNotSame(windowFunction, copy);
+    assertEquals(windowFunction, copy);
+
+    assertNotSame(copy.getOrderBys(),windowFunction.getOrderBys());
+    assertNotSame(copy.getPartitionBys(),windowFunction.getPartitionBys());
+    assertEquals(copy.getOrderBys(),windowFunction.getOrderBys());
+    assertEquals(copy.getPartitionBys(),windowFunction.getPartitionBys());
+    assertEquals(copy.getAlias(),windowFunction.getAlias());
+  }
+
+
+  /**
+   * Test the builder pattern preserves previous calls.
+   */
+  @Test
+  public void testMultipleBuilderCalls() {
+    WindowFunction windowFunction = SqlUtils.windowFunction(sum(field1))
+                                    .partitionBy(field2Asc)
+                                    .partitionBy(Lists.newArrayList(field3Desc))
+                                    .orderBy(field3Desc)
+                                    .orderBy(Lists.newArrayList(field4NoOrder))
+                                    .build();
+
+
+    assertThat(windowFunction.getOrderBys(),hasSize(2));
+    assertThat(windowFunction.getPartitionBys(),hasSize(2));
+
+  }
+
+
+  /**
+   * Tests order by direction defaulting.
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testOrderDefaulting() {
+
+    field4NoOrder.setDirection(Direction.NONE);
+
+    WindowFunction windowFunction = SqlUtils.windowFunction(sum(field1))
+                                    .orderBy(field2Asc,field3Desc,field4NoOrder)
+                                    .build();
+
+
+    assertThat(windowFunction.getOrderBys(),hasSize(3));
+    assertThat(windowFunction.getOrderBys(),contains(fieldReferenceWithNameAndDirection("field2",Direction.ASCENDING),
+                                                    fieldReferenceWithNameAndDirection("field3",Direction.DESCENDING),
+                                                    fieldReferenceWithNameAndDirection("field4",Direction.ASCENDING)));
+  }
+
+
+  private Matcher<AliasedField> fieldReferenceWithNameAndDirection(final String name,final Direction direction){
+    return new TypeSafeMatcher<AliasedField>() {
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText("Name:").appendValue(name).appendText(" Direction:").appendValue(direction);
+      }
+
+
+      @Override
+      protected boolean matchesSafely(AliasedField item) {
+        return item instanceof FieldReference && ((FieldReference) item).getDirection() == direction && name.equals(((FieldReference) item).getName()) ;
+      }
+    };
+  }
+}


### PR DESCRIPTION
First step towards #7.

The idea is to stay 100% compatible, deprecating constructors and other methods that we can't support long term and paving the way to switching to immutability.

Eventually, we will need to break compatibility to _actually_ make everything immutable, since that means that patterns like this will no longer work:

```
AliasedField myField = field("Foo");
myField.as("aliased");
runner.run(select(myField).from("Bar"));
```

However, we have lots of uses of this, so we need to allow a transition.

The  `AliasedField.IMMUTABLE_DSL_ENABLED` system property allows us to simply flick over support for mutability at run-time.   This will allow us to do the work in parallel and then switch over once we have fixed any existing uses.

This is now ready for merge.  More coming in future pull requests.
