### PR TITLE
Publishing to Maven Central

### DIFF
--- a/.maven-settings.xml
+++ b/.maven-settings.xml
@@ -1,0 +1,23 @@
+<settings xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://maven.apache.org/SETTINGS/1.0.0" xsi:schemalocation="http://maven.apache.org/SETTINGS/1.0.0 http://maven.apache.org/xsd/settings-1.0.0.xsd">
+  <servers>
+    <server>
+      <id>ossrh</id>
+      <username>${env.SONATYPE_USERNAME}</username>
+      <password>${env.SONATYPE_PASSWORD}</password>
+    </server>
+  </servers>
+
+  <profiles>
+    <profile>
+      <id>ossrh</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <gpg.keyname>${env.GPG_KEYNAME}</gpg.keyname>
+        <gpg.executable>${env.GPG_EXECUTABLE}</gpg.executable>
+        <gpg.passphrase>${env.GPG_PASSPHRASE}</gpg.passphrase>
+      </properties>
+    </profile>
+  </profiles>
+</settings>

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ jobs:
       name: "Deploy"
       script:
         - mvn clean deploy --settings .maven-settings.xml -B -U -Prelease
-    - if: NOT branch = master
+    - if: NOT branch = master OR NOT repo = alfasoftware/morf
       name: "Test"
       script:
         - mvn clean test -B -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,17 +7,17 @@ addons:
       secure: "Rk0cQ9JL2/DB8xrKjaU/m9HEvZllokUZ8c7Q+6g3DHwOsMvZi1OoCdUtDXf9Zl0xtdFPMvoWsGPeZ6+sZK9evHscvRH83hVMTrTabWK4+QL660QeMXboBprwuBIpAI0XBCfNcslsT3zPd/e4v35FHPdvRr1yOQlibrjEgs1MZo6/LQ7QgRNJAHsskiqOOJS6LLDHceYJEW7wd/y7R0BvXoxch6xQhDOFvowoc22/cEyUVCSCMMas74hD//veSXdHt0CNOY+H+/PAzAYsbM0rkJnrysqO8UgLZwpnP/Mjsoi0InoisvriSl9MYgQwMAfcrtVxxR94vt4Pu62LXsnt6ufGfwFBrdTh1Rna05fzTAmm9bwywIR2UsMwNeM4iDoz+Rc2ImnwMKRipn5lib5kCOlwqjTv6NVi0oV5XEzTfU51HIrQMmmsq60YwMZgcYwckHoVVOojv29dAjLe0Z/LbfUH8MHprt8/MdWA8ir2egxHHW3dXVY11MgDKzQ2RyYb1uPNJgkVfZDm7uHDcj13dFR61Gy1mTdrtpnWx1ojU2IJQ4oKuGb04RbqQ5lCq7dgsHlaeaAJFMlcn1I6IOk8t6QkYy/3vhSXgkZpQAO3K5Zp4aaGZD90sYdQO3JQNCe2S8mhgEGOqsAdxytFygCaMxOKG5NV9qxVilkzfGPvmqM="
 jobs:
   include:
-    - if: branch = master AND repo = alfasoftware/morf
+    - if: branch = master AND repo = alfasoftware/morf AND NOT type = pull_request
       name: "Test with coverage"
       script:
         - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test sonar:sonar -Pcoverage-per-test -Dsonar.branch.name=master -B -U
-    - if: branch = master AND repo = alfasoftware/morf
+    - if: branch = master AND repo = alfasoftware/morf AND NOT type = pull_request
       name: "Deploy"
       script:
         - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
         - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
         - mvn clean deploy --settings .maven-settings.xml -B -U -Prelease
-    - if: NOT branch = master OR NOT repo = alfasoftware/morf
+    - if: NOT branch = master OR NOT repo = alfasoftware/morf OR type = pull_request
       name: "Test"
       script:
         - mvn clean test -B -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,15 +5,24 @@ addons:
     organization: "alfasoftware"
     token:
       secure: "Rk0cQ9JL2/DB8xrKjaU/m9HEvZllokUZ8c7Q+6g3DHwOsMvZi1OoCdUtDXf9Zl0xtdFPMvoWsGPeZ6+sZK9evHscvRH83hVMTrTabWK4+QL660QeMXboBprwuBIpAI0XBCfNcslsT3zPd/e4v35FHPdvRr1yOQlibrjEgs1MZo6/LQ7QgRNJAHsskiqOOJS6LLDHceYJEW7wd/y7R0BvXoxch6xQhDOFvowoc22/cEyUVCSCMMas74hD//veSXdHt0CNOY+H+/PAzAYsbM0rkJnrysqO8UgLZwpnP/Mjsoi0InoisvriSl9MYgQwMAfcrtVxxR94vt4Pu62LXsnt6ufGfwFBrdTh1Rna05fzTAmm9bwywIR2UsMwNeM4iDoz+Rc2ImnwMKRipn5lib5kCOlwqjTv6NVi0oV5XEzTfU51HIrQMmmsq60YwMZgcYwckHoVVOojv29dAjLe0Z/LbfUH8MHprt8/MdWA8ir2egxHHW3dXVY11MgDKzQ2RyYb1uPNJgkVfZDm7uHDcj13dFR61Gy1mTdrtpnWx1ojU2IJQ4oKuGb04RbqQ5lCq7dgsHlaeaAJFMlcn1I6IOk8t6QkYy/3vhSXgkZpQAO3K5Zp4aaGZD90sYdQO3JQNCe2S8mhgEGOqsAdxytFygCaMxOKG5NV9qxVilkzfGPvmqM="
-script:
-  - SONAR_SKIP=$(if [ "$TRAVIS_PULL_REQUEST" = "false" -a $TRAVIS_REPO_SLUG = 'alfasoftware/morf' ]; then echo "false"; else echo "true"; fi)
-  - if [ $SONAR_SKIP = "false" ]; then git fetch --unshallow --quiet; fi
-  - mvn $GOALS -Dsonar.branch=$TRAVIS_BRANCH -Dsonar.skip=$SONAR_SKIP
+jobs:
+  include:
+    - if: branch = master AND repo = alfasoftware/morf
+      name: "Test with coverage"
+      script:
+        - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test sonar:sonar -Pcoverage-per-test -Dsonar.branch=master -B -U
+    - if: branch = master
+      name: "Deploy"
+      script:
+        - mvn clean deploy --settings .maven-settings.xml -B -U -Prelease
+    - if: NOT branch = master
+      name: "Test"
+      script:
+        - mvn clean test -B -U
 matrix:
   fast_finish: true
   include:
     - jdk: oraclejdk8
-      env: GOALS="clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Pcoverage-per-test"
 cache:
   directories:
     - '$HOME/.m2/repository'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ jobs:
     - if: branch = master
       name: "Deploy"
       script:
+        - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import
+        - echo $GPG_OWNERTRUST | base64 --decode | $GPG_EXECUTABLE --import-ownertrust
         - mvn clean deploy --settings .maven-settings.xml -B -U -Prelease
     - if: NOT branch = master OR NOT repo = alfasoftware/morf
       name: "Test"

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ jobs:
     - if: branch = master AND repo = alfasoftware/morf
       name: "Test with coverage"
       script:
-        - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test sonar:sonar -Pcoverage-per-test -Dsonar.branch=master -B -U
+        - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test sonar:sonar -Pcoverage-per-test -Dsonar.branch.name=master -B -U
     - if: branch = master AND repo = alfasoftware/morf
       name: "Deploy"
       script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ jobs:
       name: "Test with coverage"
       script:
         - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test sonar:sonar -Pcoverage-per-test -Dsonar.branch=master -B -U
-    - if: branch = master
+    - if: branch = master AND repo = alfasoftware/morf
       name: "Deploy"
       script:
         - echo $GPG_SECRET_KEYS | base64 --decode | $GPG_EXECUTABLE --import

--- a/pom.xml
+++ b/pom.xml
@@ -88,6 +88,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-surefire-plugin</artifactId>
           <version>${maven-surefire-plugin.version}</version>
+          <configuration>
+            <systemPropertyVariables>
+              <log4j.configuration>file:${basedir}/../etc/log4j-maven.properties</log4j.configuration>
+            </systemPropertyVariables>
+          </configuration>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -352,9 +357,6 @@
                   <value>org.sonar.java.jacoco.JUnitListener</value>
                 </property>
               </properties>
-              <systemPropertyVariables>
-                <log4j.configuration>file:${basedir}/../etc/log4j-maven.properties</log4j.configuration>
-              </systemPropertyVariables>
             </configuration>
           </plugin>
         </plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -373,12 +373,6 @@
     
     <profile>
       <id>release</id>
-      <activation>
-        <property>
-          <name>release</name>
-        </property>
-      </activation>
-      
       <properties>
         <gpg.executable>gpg2</gpg.executable>
       </properties>

--- a/pom.xml
+++ b/pom.xml
@@ -421,8 +421,98 @@
   
   <developers>
     <developer>
+      <name>Alex Vinall</name>
+      <email>alex.vinall@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Andrew Flegg</name>
+      <email>andrew.flegg@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Bruno Correia</name>
+      <email>bruno.correia@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Charlotte de Grouchy</name>
+      <email>charlotte.degrouchy@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Frank Sloan</name>
+      <email>frank.sloan@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
       <name>Graham Crockford</name>
       <email>graham.crockford@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Harry Austin</name>
+      <email>harry.austin@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>James Leach</name>
+      <email>james.leach@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Joseph Hoare</name>
+      <email>joseph.hoare@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Juraj Simlovic</name>
+      <email>juraj.simlovic@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Luigi Iannone</name>
+      <email>luigi.iannone@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Michal Morzywolek</name>
+      <email>michal.morzywolek@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Przemyslaw Stefaniak</name>
+      <email>przemyslaw.stefaniak@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Tim Gage</name>
+      <email>tim.gage@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Venushka Perera</name>
+      <email>venushka.perera@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+    <developer>
+      <name>Will Nicholson</name>
+      <email>will.nicholson@alfasystems.com</email>
       <organization>Alfa Financial Software Limited</organization>
       <organizationUrl>http://alfasystems.com</organizationUrl>
     </developer>

--- a/pom.xml
+++ b/pom.xml
@@ -368,24 +368,89 @@
         </dependency>
       </dependencies>
     </profile>
+    
+    <profile>
+      <id>release</id>
+      <activation>
+        <property>
+          <name>release</name>
+        </property>
+      </activation>
+      
+      <properties>
+        <gpg.executable>gpg2</gpg.executable>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.7</version>
+            <extensions>true</extensions>
+            <configuration>
+              <serverId>ossrh</serverId>
+              <nexusUrl>https://oss.sonatype.org/</nexusUrl>
+              <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            </configuration>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>1.6</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <keyname>${gpg.keyname}</keyname>
+                  <passphraseServerId>${gpg.keyname}</passphraseServerId>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
   </profiles>
 
-<!--   <scm> -->
-<!--     <connection>scm:?????</connection> -->
-<!--     <developerConnection>scm:?????</developerConnection> -->
-<!--     <url>?????</url> -->
-<!--   </scm> -->
+  <licenses>
+    <license>
+      <name>The Apache License, Version 2.0</name>
+      <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+    </license>
+  </licenses>
   
-<!--   <distributionManagement> -->
-<!--     <repository> -->
-<!--       <id>?????</id> -->
-<!--       <name>Releases</name> -->
-<!--       <url>http://?????</url> -->
-<!--     </repository> -->
-<!--     <snapshotRepository> -->
-<!--       <id>?????</id> -->
-<!--       <name>Snapshots</name> -->
-<!--       <url>http://?????</url> -->
-<!--     </snapshotRepository> -->
-<!--   </distributionManagement> -->
+  <developers>
+    <developer>
+      <name>Graham Crockford</name>
+      <email>graham.crockford@alfasystems.com</email>
+      <organization>Alfa Financial Software Limited</organization>
+      <organizationUrl>http://alfasystems.com</organizationUrl>
+    </developer>
+  </developers>
+
+  <issueManagement>
+    <system>GitHub Issues</system>
+    <url>https://github.com/alfasoftware/morf/issues</url>
+  </issueManagement>
+  
+  <scm>
+    <connection>scm:git:https://github.com/alfasoftware/morf.git</connection>
+    <developerConnection>scm:git:git@github.com:alfasoftware/morf.git</developerConnection>
+    <url>https://github.com/alfasoftware/morf</url>
+  </scm>
+  
+  <distributionManagement>
+    <snapshotRepository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+    </snapshotRepository>
+    <repository>
+      <id>ossrh</id>
+      <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+    </repository>
+  </distributionManagement>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -421,80 +421,14 @@
   
   <developers>
     <developer>
-      <name>Alex Vinall</name>
-      <email>alex.vinall@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
       <name>Andrew Flegg</name>
       <email>andrew.flegg@alfasystems.com</email>
       <organization>Alfa Financial Software Limited</organization>
       <organizationUrl>http://alfasystems.com</organizationUrl>
     </developer>
     <developer>
-      <name>Bruno Correia</name>
-      <email>bruno.correia@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Charlotte de Grouchy</name>
-      <email>charlotte.degrouchy@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Frank Sloan</name>
-      <email>frank.sloan@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
       <name>Graham Crockford</name>
       <email>graham.crockford@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Harry Austin</name>
-      <email>harry.austin@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>James Leach</name>
-      <email>james.leach@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Joseph Hoare</name>
-      <email>joseph.hoare@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Juraj Simlovic</name>
-      <email>juraj.simlovic@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Luigi Iannone</name>
-      <email>luigi.iannone@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Michal Morzywolek</name>
-      <email>michal.morzywolek@alfasystems.com</email>
-      <organization>Alfa Financial Software Limited</organization>
-      <organizationUrl>http://alfasystems.com</organizationUrl>
-    </developer>
-    <developer>
-      <name>Przemyslaw Stefaniak</name>
-      <email>przemyslaw.stefaniak@alfasystems.com</email>
       <organization>Alfa Financial Software Limited</organization>
       <organizationUrl>http://alfasystems.com</organizationUrl>
     </developer>


### PR DESCRIPTION
Implements #56

I've updated the POM to be compliant with the requirements stated on Maven Central publishing guide and changed the build to publish to Maven Central automatically.

The build has been changed so that,
- builds of **master** now has two jobs,
  -  _test_ job that runs tests and publishes coverage data to SonarCloud
  - _deploy_ job that runs tests and publishes to Maven Central
     - This will publish a SNAPSHOT build if the pom.xml has a -SNAPSHOT version
     - Otherwise, will publish a release*
- builds of **pull requests** or **branches** no has one job,
  - _test_ job that runs the tests. 
- builds of **any fork**, does not matter if its master/pull request/branch, they will all has one job,
  - _test_ job that runs the tests.

I've successfully published two snapshots to https://oss.sonatype.org/content/repositories/snapshots/org/alfasoftware/. I've since change the travis.yaml file to not allow publishing from forks, so going forward, all publishing will only happen from this repository's master.

I have not tested publishing a release as I'm not sure if we want to publish a release now or after checking the open item for the initial release. This should work given the authentication, signing and publishing all works.

\* When publishing a release, we'll need to push a change with the fixed version number in the pom.xml and let a build run to publish. We probably should use the Maven release plugin, but that complicates the publishing process, so we'll probably revisit this again at some point? (using the release plugin will give us benefits like failing releases when using snapshots, but I guess this project is small enough to manage these ourselves?)

Also need to remember that publishing a release itself is not enough, we'll have to **push the release from staging** environment as described here: https://central.sonatype.org/pages/releasing-the-deployment.html
