### PR TITLE
Fixing shallow clone warning

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,14 +10,17 @@ jobs:
     - if: repo = alfasoftware/morf AND branch = master AND NOT type = pull_request
       name: "Test"
       script:
+        - git fetch --unshallow --quiet
         - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test sonar:sonar -Pcoverage-per-test -B -U
     - if: repo = alfasoftware/morf AND NOT branch = master AND NOT type = pull_request
       name: "Test"
       script:
+        - git fetch --unshallow --quiet
         - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test sonar:sonar -Pcoverage-per-test -B -U -Dsonar.branch.name=$TRAVIS_BRANCH
     - if: repo = alfasoftware/morf AND type = pull_request
       name: "Test"
       script:
+        - git fetch --unshallow --quiet
         - mvn clean org.jacoco:jacoco-maven-plugin:prepare-agent test sonar:sonar -Pcoverage-per-test -B -U -Dsonar.pullrequest.key=$TRAVIS_PULL_REQUEST -Dsonar.pullrequest.branch=$TRAVIS_PULL_REQUEST_BRANCH -Dsonar.pullrequest.base=$TRAVIS_BRANCH
     - if: repo = alfasoftware/morf AND branch = master AND NOT type = pull_request
       name: "Deploy"


### PR DESCRIPTION
Fixes #66 as it was accidentally removed while updating Travis configuration to do branch analysis.