### PR TITLE
Connector driver 8 support

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/DatabaseMetaDataProvider.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/DatabaseMetaDataProvider.java
@@ -223,7 +223,7 @@ public class DatabaseMetaDataProvider implements Schema {
     try {
       final DatabaseMetaData databaseMetaData = connection.getMetaData();
 
-      try (ResultSet primaryKeyResults = databaseMetaData.getPrimaryKeys(null, schemaName, tableName)) {
+      try (ResultSet primaryKeyResults = databaseMetaData.getPrimaryKeys(schemaName, schemaName, tableName)) {
         while (primaryKeyResults.next()) {
           columns.add(new PrimaryKeyColumn(primaryKeyResults.getShort(5), primaryKeyResults.getString(4)));
         }
@@ -588,13 +588,12 @@ public class DatabaseMetaDataProvider implements Schema {
     try {
       final DatabaseMetaData databaseMetaData = connection.getMetaData();
 
-      try (ResultSet tables = databaseMetaData.getTables(null, schemaName, null, TABLE_TYPES)) {
+      try (ResultSet tables = databaseMetaData.getTables(schemaName, schemaName, null, TABLE_TYPES)) {
         while (tables.next()) {
           String tableName = tables.getString(3);
-          String tableSchemaName = tables.getString(2);
           String tableType = tables.getString(4);
 
-          foundTable(tableName, tableSchemaName, tableType);
+          foundTable(tableName, schemaName, tableType);
         }
       }
     } catch (SQLException sqle) {

--- a/morf-core/src/main/java/org/alfasoftware/morf/metadata/SchemaUtils.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/metadata/SchemaUtils.java
@@ -609,7 +609,7 @@ public final class SchemaUtils {
      */
     @Override
     public ColumnBuilder autoNumbered(int from) {
-      return new ColumnBuilderImpl(this, isNullable(), getDefaultValue(), isPrimaryKey(), true, from);
+      return new ColumnBuilderImpl(this, isNullable(), getDefaultValue(), true, true, from);
     }
 
 


### PR DESCRIPTION
Some initial testing with the Connector/J 8+ driver highlighted a few issues which were easily fixed and shouldn't affect compatibility with the old driver.

There's still a warning about using a deprecated driver classname on startup, but that's less safe to resolve for the moment.