### PR TITLE
Bumping up version of h2 database

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -52,7 +52,7 @@
     <commons-logging.version>1.2</commons-logging.version>
     <guava.version>27.0-jre</guava.version>
     <guice.version>4.2.0</guice.version>
-    <h2.version>1.4.196</h2.version>
+    <h2.version>1.4.199</h2.version>
     <hamcrest.version>1.3</hamcrest.version>
     <joda-time.version>2.1</joda-time.version>
     <junit.version>4.11</junit.version>


### PR DESCRIPTION
We need to upgrade H2 database dependency to version 1.4.199 to add support for row level locking (SELECT FOR UPDATE).