### PR TITLE
Fix build on Java 11

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ target
 *.iml
 .idea
 **/ivy-ide-settings.properties
+**.versionsBackup

--- a/morf-core/pom.xml
+++ b/morf-core/pom.xml
@@ -100,5 +100,17 @@
       <artifactId>log4j</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/SqlUtils.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/SqlUtils.java
@@ -745,7 +745,6 @@ parameter("name").type(DataType.DECIMAL).width(13,2)</pre>
    * <li>orderBy(..) is optional. If not specified the entire partition will be used as the window frame. If specified a range between the first row and the current row of the window is used (i.e. RANGE UNBOUNDED PRECEDING AND CURRENT ROW for Oracle).</li>
    * <li>The default direction for fields in orderBy(..) is ASC.</li>
    * </ul>
-   * @author Copyright (c) Alfa Financial Software 2017
    * @param function The function
    * @return The windowing function builder
    */

--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,21 @@
 	    <groupId>org.xmlunit</groupId>
 	    <artifactId>xmlunit-matchers</artifactId>
 	    <version>${xmlunit.version}</version>
-	  </dependency>
+	  </dependency>      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-core</artifactId>
+        <version>2.3.0.1</version>
+      </dependency>
+      <dependency>
+        <groupId>com.sun.xml.bind</groupId>
+        <artifactId>jaxb-impl</artifactId>
+        <version>2.3.2</version>
+      </dependency>
     </dependencies>
   </dependencyManagement>
 

--- a/pom.xml
+++ b/pom.xml
@@ -392,7 +392,8 @@
 	    <groupId>org.xmlunit</groupId>
 	    <artifactId>xmlunit-matchers</artifactId>
 	    <version>${xmlunit.version}</version>
-	  </dependency>      <dependency>
+	  </dependency>
+    <dependency>
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>2.3.1</version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <maven-compiler-plugin.version>3.6.1</maven-compiler-plugin.version>
     <maven-deploy-plugin.version>2.8.2</maven-deploy-plugin.version>
     <maven-jar-plugin.version>2.4</maven-jar-plugin.version>
-    <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
+    <maven-javadoc-plugin.version>3.1.1</maven-javadoc-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
     <maven-surefire-plugin.version>2.13</maven-surefire-plugin.version>
@@ -383,7 +383,7 @@
         <artifactId>serializer</artifactId>
         <version>${serializer.version}</version>
       </dependency>
-	  <dependency>
+      <dependency>
 	    <groupId>org.xmlunit</groupId>
 	    <artifactId>xmlunit-core</artifactId>
 	    <version>${xmlunit.version}</version>


### PR DESCRIPTION
Note that this still has to be run with `-Dfindbugs.skip=true` as findbugs is not Java 11 compatible.

Switching to spotbugs is easy.