### PR TITLE
Copy the licence into jars when deploying

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,7 +242,6 @@
         <artifactId>morf-sqlserver</artifactId>
         <version>${project.version}</version>
       </dependency>
-
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
@@ -395,6 +394,15 @@
         <gpg.executable>gpg2</gpg.executable>
       </properties>
       <build>
+        <resources>
+          <resource>
+            <directory>${project.basedir}/..</directory>
+            <includes>
+              <include>LICENSE</include>
+            </includes>
+            <targetPath>META-INF/</targetPath>
+          </resource>
+        </resources>
         <plugins>
           <plugin>
             <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
It's helpful for the released jars to all contain the licence.

Seeing as we always deploy morf-parent, I've used `${project.baseDir}/..` to get 'up' one level to the root.