### PR TITLE
Revert "Copy the licence into jars when deploying"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -242,6 +242,7 @@
         <artifactId>morf-sqlserver</artifactId>
         <version>${project.version}</version>
       </dependency>
+
       <dependency>
         <groupId>commons-codec</groupId>
         <artifactId>commons-codec</artifactId>
@@ -394,15 +395,6 @@
         <gpg.executable>gpg2</gpg.executable>
       </properties>
       <build>
-        <resources>
-          <resource>
-            <directory>${project.basedir}/..</directory>
-            <includes>
-              <include>LICENSE</include>
-            </includes>
-            <targetPath>META-INF/</targetPath>
-          </resource>
-        </resources>
         <plugins>
           <plugin>
             <groupId>org.sonatype.plugins</groupId>


### PR DESCRIPTION
Reverts alfasoftware/morf#91

The change has meant an incomplete set of resources are pulled with the release profile and is failing when deploying