### PR TITLE
Lazy table columns info loading

### DIFF
--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
@@ -36,6 +36,7 @@ import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
 import java.util.function.Function;
@@ -61,7 +62,9 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
+import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Iterables;
 import com.google.inject.Inject;
 
 /**
@@ -143,6 +146,11 @@ public class TestDatabaseMetaDataProvider {
     schemaManager.dropAllTables();
     schemaManager.mutateToSupportSchema(schema, TruncationBehavior.ALWAYS);
 
+    try (Connection connection = database.getDataSource().getConnection()) {
+      String schema = Strings.isNullOrEmpty(database.getSchemaName()) ? "" : database.getSchemaName() + ".";
+      connection.createStatement().executeUpdate("CREATE TABLE " + schema + "WithTimestamp (special TIMESTAMP)");
+    }
+
     readMysqlLowerCaseTableNames();
   }
 
@@ -173,14 +181,16 @@ public class TestDatabaseMetaDataProvider {
       assertThat(schemaResource.tableNames(), containsInAnyOrder(ImmutableList.of(
         tableNameEqualTo("WithTypes"),
         tableNameEqualTo("WithDefaults"),
-        tableNameEqualTo("WithLobs")
+        tableNameEqualTo("WithLobs"),
+        equalToIgnoringCase("WithTimestamp") // can read table names even if they contain unsupported columns
       )));
 
 
       assertThat(schemaResource.tables(), containsInAnyOrder(ImmutableList.of(
         tableNameMatcher("WithTypes"),
         tableNameMatcher("WithDefaults"),
-        tableNameMatcher("WithLobs")
+        tableNameMatcher("WithLobs"),
+        propertyMatcher(Table::getName, "name", equalToIgnoringCase("WithTimestamp")) // can read table names even if they contain unsupported columns
       )));
     }
   }
@@ -312,6 +322,30 @@ public class TestDatabaseMetaDataProvider {
       ));
 
       assertThat(table.indexes(), empty());
+    }
+  }
+
+
+  @Test
+  public void testTableWithTimestamp() throws SQLException {
+    try(SchemaResource schemaResource = database.openSchemaResource()) {
+      assertTrue(schemaResource.tableExists("WithTimestamp"));
+      Table table = schemaResource.getTable("WithTimestamp");
+
+      assertThat(table.isTemporary(), is(false));
+      assertThat(table.getName(), equalToIgnoringCase("WithTimestamp"));
+
+      assertThat(table.columns(), containsColumns(ImmutableList.of(
+        propertyMatcher(Column::getName, "name", equalToIgnoringCase("special")) // can read column names even if they contain unsupported data types
+      )));
+
+      try {
+        Iterables.getOnlyElement(table.columns()).getType();
+        fail("Exception expected");
+      }
+      catch (DatabaseMetaDataProvider.UnexpectedDataTypeException e) { /* expected*/ }
+
+      assertThat(table.indexes(), empty()); // can read indexes, as long as unsupported data types are not involved
     }
   }
 

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
@@ -155,7 +155,13 @@ public class TestDatabaseMetaDataProvider {
   }
 
   @After
-  public void after() {
+  public void after() throws SQLException {
+    // must cleanup, otherwise other tests could try to read this table and fail
+    try (Connection connection = database.getDataSource().getConnection()) {
+      String schema = Strings.isNullOrEmpty(database.getSchemaName()) ? "" : database.getSchemaName() + ".";
+      connection.createStatement().executeUpdate("DROP TABLE " + schema + "WithTimestamp");
+    }
+
     schemaManager.invalidateCache();
   }
 

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleMetaDataProvider.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleMetaDataProvider.java
@@ -38,6 +38,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider;
+import org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider.UnexpectedDataTypeException;
 import org.alfasoftware.morf.jdbc.DatabaseMetaDataProviderUtils;
 import org.alfasoftware.morf.jdbc.RuntimeSqlException;
 import org.alfasoftware.morf.metadata.Column;
@@ -512,7 +513,7 @@ public class OracleMetaDataProvider implements Schema {
       return DataType.DATE;
     }
     else {
-      throw new UnexpectedDataTypeException("Unsupported data type [" + dataTypeName + "]" + " in [" + columnName + "]");
+      throw new DatabaseMetaDataProvider.UnexpectedDataTypeException("Unsupported data type [" + dataTypeName + "]" + " in [" + columnName + "]");
     }
   }
 
@@ -898,17 +899,6 @@ public class OracleMetaDataProvider implements Schema {
     @Override
     public String toString() {
       return this.toStringHelper();
-    }
-  }
-
-
-  /**
-   * Exception thrown when data type evaluated is unsupported.
-   */
-  public static final class UnexpectedDataTypeException extends RuntimeException {
-
-    private UnexpectedDataTypeException(String string) {
-      super(string);
     }
   }
 }


### PR DESCRIPTION
Allow unsupported column data types in the source schema, as long as the column details of such columns are not inspected. Only column names can be read safely, other column attributes throw UnexpectedDataTypeException. This already worked as described for the Oracle dialect. Now expadning this feature to all dialects, which utilise DatabaseMetaDataProvider (H2, MySQL, Postgres, etc.).