### PR TITLE
Lazy table columns info loading

### DIFF
--- a/morf-core/pom.xml
+++ b/morf-core/pom.xml
@@ -40,14 +40,6 @@
 
   <dependencies>
     <dependency>
-      <groupId>commons-codec</groupId>
-      <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>commons-io</groupId>
-      <artifactId>commons-io</artifactId>
-    </dependency>
-    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/DatabaseMetaDataProvider.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/DatabaseMetaDataProvider.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -881,15 +880,15 @@ public class DatabaseMetaDataProvider implements Schema {
     }
 
     @Override
-    public int hashCode() {
+    public final int hashCode() { // final intentional!
       return hashCode;
     }
 
     @Override
-    public boolean equals(Object obj) {
+    public final boolean equals(Object obj) { // final intentional!
       if (this == obj) return true;
       if (obj == null) return false;
-      if (!(obj instanceof AName)) return false; // instanceof is fine as we actually want to consider children
+      if (!(obj instanceof AName)) return false; // instanceof intentional!
       AName that = (AName) obj;
       return this.aName.equalsIgnoreCase(that.aName);
     }
@@ -927,20 +926,6 @@ public class DatabaseMetaDataProvider implements Schema {
     @Override
     public String toString() {
       return getDbName() + "/" + getRealName();
-    }
-
-    @Override
-    public boolean equals(Object o) {
-      if (this == o) return true;
-      if (o == null || getClass() != o.getClass()) return false;
-      if (!super.equals(o)) return false;
-      RealName realName1 = (RealName) o;
-      return Objects.equals(realName, realName1.realName);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(super.hashCode(), realName);
     }
   }
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -23,6 +23,8 @@ import static org.alfasoftware.morf.sql.SqlUtils.insert;
 import static org.alfasoftware.morf.sql.SqlUtils.tableRef;
 import static org.alfasoftware.morf.sql.UnionSetOperator.UnionStrategy.ALL;
 
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.sql.Connection;
 import java.sql.Date;
 import java.sql.PreparedStatement;
@@ -90,7 +92,6 @@ import org.alfasoftware.morf.sql.element.WhenCondition;
 import org.alfasoftware.morf.sql.element.WindowFunction;
 import org.alfasoftware.morf.upgrade.ChangeColumn;
 import org.alfasoftware.morf.util.ObjectTreeTraverser;
-import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.joda.time.LocalDate;
@@ -103,6 +104,8 @@ import com.google.common.collect.ImmutableList.Builder;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
+import com.google.common.hash.Hashing;
+import com.google.common.io.CharSource;
 
 /**
  * Provides functionality for generating SQL statements.
@@ -2413,8 +2416,9 @@ public abstract class SqlDialect {
    * @return A hash representation of {@code statement}.
    */
   public String convertStatementToHash(SelectStatement statement) {
-    return DigestUtils.md5Hex(convertStatementToSQL(statement));
+    return md5HashHexEncoded(convertStatementToSQL(statement));
   }
+
 
 
   /**
@@ -2424,7 +2428,21 @@ public abstract class SqlDialect {
    * @return A hash representation of {@code statement}.
    */
   public String convertStatementToHash(SelectFirstStatement statement) {
-    return DigestUtils.md5Hex(convertStatementToSQL(statement));
+    return md5HashHexEncoded(convertStatementToSQL(statement));
+  }
+
+
+  /**
+   * @param toHash the String to convert
+   * @return the md5 hash of the string.
+   */
+  @SuppressWarnings("deprecation")
+  private String md5HashHexEncoded(String toHash) {
+    try {
+      return CharSource.wrap(toHash).asByteSource(StandardCharsets.UTF_8).hash(Hashing.md5()).toString();
+    } catch (IOException e) {
+      throw new RuntimeException("error when hashing string [" + toHash + "]", e);
+    }
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/metadata/DataValueLookup.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/metadata/DataValueLookup.java
@@ -18,9 +18,9 @@ package org.alfasoftware.morf.metadata;
 
 import java.math.BigDecimal;
 import java.sql.ResultSet;
+import java.util.Base64;
 import java.util.List;
 
-import org.apache.commons.codec.binary.Base64;
 import org.joda.time.LocalDate;
 
 import com.google.common.collect.Iterables;
@@ -196,7 +196,7 @@ Arrays.equals(Base64.encode(myString), DataSetUtils.record().setString("foo", my
    */
   public default byte[] getByteArray(String name) {
     String value = getValue(name);
-    return value == null ? null : Base64.decodeBase64(value);
+    return value == null ? null : Base64.getDecoder().decode(value);
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/metadata/ValueConverters.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/metadata/ValueConverters.java
@@ -16,8 +16,8 @@
 package org.alfasoftware.morf.metadata;
 
 import java.math.BigDecimal;
+import java.util.Base64;
 
-import org.apache.commons.codec.binary.Base64;
 import org.joda.time.LocalDate;
 
 /**
@@ -285,7 +285,7 @@ final class ValueConverters {
     }
     @Override
     public String stringValue(byte[] value) {
-      return Base64.encodeBase64String(value);
+      return new String(Base64.getEncoder().encode(value));
     }
   }
 
@@ -365,7 +365,7 @@ final class ValueConverters {
 
     @Override
     public byte[] byteArrayValue(String value) {
-      return Base64.decodeBase64(value);
+      return Base64.getDecoder().decode(value);
     }
   }
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/xml/XmlDataSetProducer.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/xml/XmlDataSetProducer.java
@@ -36,6 +36,7 @@ import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -66,7 +67,6 @@ import org.alfasoftware.morf.metadata.SchemaUtils;
 import org.alfasoftware.morf.metadata.Table;
 import org.alfasoftware.morf.metadata.View;
 import org.alfasoftware.morf.xml.XmlStreamProvider.XmlInputStreamProvider;
-import org.apache.commons.codec.binary.Base64;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -450,7 +450,7 @@ public class XmlDataSetProducer implements DataSetProducer {
     //
     if (urlUsername != null && urlPassword != null) {
       String userpass = urlUsername + ":" + urlPassword;
-      String basicAuth = "Basic " + Base64.encodeBase64String(userpass.getBytes(StandardCharsets.UTF_8));
+      String basicAuth = "Basic " + new String(Base64.getEncoder().encode(userpass.getBytes(StandardCharsets.UTF_8)));
       urlConnection.setRequestProperty("Authorization", basicAuth);
     }
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/metadata/TestDataSetUtils.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/metadata/TestDataSetUtils.java
@@ -23,7 +23,6 @@ import org.alfasoftware.morf.dataset.BaseRecordMatcher;
 import org.alfasoftware.morf.dataset.Record;
 import org.alfasoftware.morf.metadata.DataSetUtils.RecordBuilder;
 import org.alfasoftware.morf.metadata.DataSetUtils.RecordDecorator;
-import org.apache.commons.codec.binary.Base64;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 
@@ -203,8 +202,8 @@ public class TestDataSetUtils {
     assertEquals(false, record().setString(col, "tru")  .getBoolean(col));
 
     byte[] blobValue = new byte[] { 1, 2, 3, 4, 5 };
-    assertEquals(Base64.encodeBase64String(blobValue), record().setString(col, Base64.encodeBase64String(blobValue)).getString(col));
-    assertArrayEquals(blobValue,                       record().setString(col, Base64.encodeBase64String(blobValue)).getByteArray(col));
+    assertEquals(encodeToBase64String(blobValue), record().setString(col, encodeToBase64String(blobValue)).getString(col));
+    assertArrayEquals(blobValue,                       record().setString(col, encodeToBase64String(blobValue)).getByteArray(col));
   }
 
 
@@ -324,7 +323,7 @@ public class TestDataSetUtils {
         .value(DATE_COLUMN, "1990-01-01")
         .value(LOCAL_DATE_COLUMN, "1990-01-02")
         .value(LONG_COLUMN, "2")
-        .value(BLOB_COLUMN, Base64.encodeBase64String(new byte[] { -126, 126 })),
+        .value(BLOB_COLUMN, encodeToBase64String(new byte[] { -126, 126 })),
       mutatedMatcher()
     );
   }
@@ -446,7 +445,7 @@ public class TestDataSetUtils {
       .withObject(column(LOCAL_DATE_COLUMN, DataType.DATE), java.sql.Date.valueOf(LOCAL_DATE.toString()))
       .withValue(LONG_COLUMN, LONG.toString())
       .withObject(column(LONG_COLUMN, DataType.BIG_INTEGER), LONG)
-      .withValue(BLOB_COLUMN, Base64.encodeBase64String(BYTE_ARRAY))
+      .withValue(BLOB_COLUMN, encodeToBase64String(BYTE_ARRAY))
       .withObject(column(BLOB_COLUMN, DataType.BLOB), BYTE_ARRAY)
       .withValue(UNTYPED_COLUMN, VALUE)
       .withObject(column(UNTYPED_COLUMN, DataType.STRING), VALUE);
@@ -469,9 +468,15 @@ public class TestDataSetUtils {
       .withObject(column(LOCAL_DATE_COLUMN, DataType.DATE), java.sql.Date.valueOf("1990-01-02"))
       .withValue(LONG_COLUMN, "2")
       .withObject(column(LONG_COLUMN, DataType.BIG_INTEGER), 2L)
-      .withValue(BLOB_COLUMN, Base64.encodeBase64String(new byte[] { -126, 126 }))
+      .withValue(BLOB_COLUMN, encodeToBase64String(new byte[] { -126, 126 }))
       .withObject(column(BLOB_COLUMN, DataType.BLOB), new byte[] { -126, 126 })
       .withValue(UNTYPED_COLUMN, VALUE)
       .withObject(column(UNTYPED_COLUMN, DataType.STRING), VALUE);
   }
+
+
+  private String encodeToBase64String(byte[] toEncode) {
+    return new String(java.util.Base64.getEncoder().encode(toEncode));
+  }
+
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/metadata/TestDataValueLookupTemporaryDefaultMethods.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/metadata/TestDataValueLookupTemporaryDefaultMethods.java
@@ -10,7 +10,6 @@ import static org.junit.Assert.assertTrue;
 import java.math.BigDecimal;
 import java.util.Arrays;
 
-import org.apache.commons.codec.binary.Base64;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 
@@ -155,12 +154,12 @@ public class TestDataValueLookupTemporaryDefaultMethods {
   @Test
   public void testGetByteArray() {
     byte[] data = new byte[]{ -127, -126, -125, 125, 126, 127 };
-    DataValueLookup dataValueLookup = newDataValueLookup(Base64.encodeBase64String(data));
+    DataValueLookup dataValueLookup = newDataValueLookup(encodeToBase64String(data));
     assertThat(dataValueLookup.getByteArray("B"), nullValue());
     assertTrue(Arrays.equals(dataValueLookup.getByteArray(FIELD), data));
     assertTrue(Arrays.equals(dataValueLookup.getByteArray(FIELD.toUpperCase()), data));
     assertTrue(Arrays.equals((byte[])dataValueLookup.getObject(SchemaUtils.column(FIELD, DataType.BLOB)), data));
-    assertEquals(dataValueLookup.getObject(column(FIELD, DataType.STRING)), Base64.encodeBase64String(data));
+    assertEquals(dataValueLookup.getObject(column(FIELD, DataType.STRING)), encodeToBase64String(data));
   }
 
 
@@ -172,5 +171,10 @@ public class TestDataValueLookupTemporaryDefaultMethods {
       }
     };
     return dataValueLookup;
+  }
+
+
+  private String encodeToBase64String(byte[] toEncode) {
+    return new String(java.util.Base64.getEncoder().encode(toEncode));
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -47,8 +47,6 @@
     <checkstyle.version>8.12</checkstyle.version>
 
     <!-- dependency versions -->
-    <commons-codec.version>1.9</commons-codec.version>
-    <commons-io.version>2.0.1</commons-io.version>
     <commons-lang3.version>3.8</commons-lang3.version>
     <commons-logging.version>1.2</commons-logging.version>
     <guava.version>27.0-jre</guava.version>
@@ -279,16 +277,6 @@
         <version>${project.version}</version>
       </dependency>
 
-      <dependency>
-        <groupId>commons-codec</groupId>
-        <artifactId>commons-codec</artifactId>
-        <version>${commons-codec.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>commons-io</groupId>
-        <artifactId>commons-io</artifactId>
-        <version>${commons-io.version}</version>
-      </dependency>
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-lang3</artifactId>


### PR DESCRIPTION
Fixing DatabaseMetaDataProvider.RealName equals() and hashCode() methods:
They should act like AName's when comparing to any other ANames.