### PR TITLE
Correct MySQL connection error message text

### DIFF
--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySql.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySql.java
@@ -90,7 +90,7 @@ public final class MySql extends AbstractDatabaseType {
       dataSource.getClass().getMethod("setPinGlobalTxToPhysicalConnection", boolean.class).invoke(dataSource, true);
       return dataSource;
     } catch (Exception e) {
-      throw new IllegalStateException("Failed to create Oracle XA data source", e);
+      throw new IllegalStateException("Failed to create MySQL XA data source", e);
     }
   }
 


### PR DESCRIPTION
In the MySQL module there is a reference to Oracle. Probably a cut and paste where the change got missed. It is a one word change inside an error message string so it should be a trivial change. 