### PR TITLE
Unit test failure - text in Japanese - fix WEB-116913

### DIFF
--- a/morf-integration-test/pom.xml
+++ b/morf-integration-test/pom.xml
@@ -106,11 +106,5 @@
       <artifactId>JUnitParams</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>com.alfasystems</groupId>
-      <artifactId>alfa-subetha-testsupport</artifactId>
-      <version>1.18.0</version>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
 </project>

--- a/morf-integration-test/pom.xml
+++ b/morf-integration-test/pom.xml
@@ -1,12 +1,12 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
   <modelVersion>4.0.0</modelVersion>
-  
+
   <parent>
     <groupId>org.alfasoftware</groupId>
     <artifactId>morf-parent</artifactId>
     <version>1.2.10-SNAPSHOT</version>
   </parent>
-  
+
   <name>Morf - Integration Test</name>
   <description>Morf is a library for cross-platform evolutionary relational database mechanics, database access and database imaging/cloning.</description>
   <url>https://github.com/alfasoftware/morf</url>
@@ -104,6 +104,12 @@
     <dependency>
       <groupId>pl.pragmatists</groupId>
       <artifactId>JUnitParams</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.alfasystems</groupId>
+      <artifactId>alfa-subetha-testsupport</artifactId>
+      <version>1.18.0</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestDatabaseUpgradeIntegration.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestDatabaseUpgradeIntegration.java
@@ -15,7 +15,6 @@
 
 package org.alfasoftware.morf.integration;
 
-import com.chpconsulting.subetha.util.LocaleRule;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Lists;
@@ -146,8 +145,6 @@ public class TestDatabaseUpgradeIntegration {
 
   /***/
   @Rule public InjectMembersRule injectMembersRule = new InjectMembersRule(new TestingDataSourceModule());
-
-  @Rule public LocaleRule localeRule = new LocaleRule(Locale.UK);
 
   @Inject
   private Provider<DatabaseDataSetConsumer> databaseDataSetConsumer;
@@ -310,6 +307,7 @@ public class TestDatabaseUpgradeIntegration {
    */
   @Before
   public void before() {
+    Locale.setDefault(new Locale("en", "GB"));
     schemaManager.get().dropAllViews();
     schemaManager.get().dropAllTables();
     schemaManager.get().mutateToSupportSchema(schema, TruncationBehavior.ALWAYS);

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestDatabaseUpgradeIntegration.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestDatabaseUpgradeIntegration.java
@@ -15,43 +15,14 @@
 
 package org.alfasoftware.morf.integration;
 
-import static com.google.common.base.Predicates.compose;
-import static com.google.common.base.Predicates.equalTo;
-import static com.google.common.base.Predicates.not;
-import static java.util.Collections.singletonList;
-import static java.util.stream.Collectors.toSet;
-import static org.alfasoftware.morf.metadata.DataSetUtils.dataSetProducer;
-import static org.alfasoftware.morf.metadata.DataSetUtils.record;
-import static org.alfasoftware.morf.metadata.SchemaUtils.column;
-import static org.alfasoftware.morf.metadata.SchemaUtils.copy;
-import static org.alfasoftware.morf.metadata.SchemaUtils.idColumn;
-import static org.alfasoftware.morf.metadata.SchemaUtils.index;
-import static org.alfasoftware.morf.metadata.SchemaUtils.schema;
-import static org.alfasoftware.morf.metadata.SchemaUtils.table;
-import static org.alfasoftware.morf.metadata.SchemaUtils.view;
-import static org.alfasoftware.morf.sql.SqlUtils.field;
-import static org.alfasoftware.morf.sql.SqlUtils.insert;
-import static org.alfasoftware.morf.sql.SqlUtils.literal;
-import static org.alfasoftware.morf.sql.SqlUtils.select;
-import static org.alfasoftware.morf.sql.SqlUtils.tableRef;
-import static org.alfasoftware.morf.upgrade.db.DatabaseUpgradeTableContribution.deployedViewsTable;
-import static org.alfasoftware.morf.upgrade.db.DatabaseUpgradeTableContribution.upgradeAuditTable;
-import static org.hamcrest.Matchers.equalToIgnoringCase;
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
-import static org.junit.Assert.fail;
-
-import java.math.BigDecimal;
-import java.sql.Connection;
-import java.sql.ResultSet;
-import java.sql.SQLException;
-import java.util.Collections;
-import java.util.List;
-import java.util.Map;
-
-import javax.sql.DataSource;
-
+import com.chpconsulting.subetha.util.LocaleRule;
+import com.google.common.collect.FluentIterable;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.Lists;
+import com.google.common.collect.Maps;
+import com.google.inject.Inject;
+import com.google.inject.Provider;
+import net.jcip.annotations.NotThreadSafe;
 import org.alfasoftware.morf.dataset.DataSetConnector;
 import org.alfasoftware.morf.dataset.DataSetProducer;
 import org.alfasoftware.morf.dataset.Record;
@@ -117,14 +88,42 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 
-import com.google.common.collect.FluentIterable;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.Lists;
-import com.google.common.collect.Maps;
-import com.google.inject.Inject;
-import com.google.inject.Provider;
+import javax.sql.DataSource;
+import java.math.BigDecimal;
+import java.sql.Connection;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.util.Collections;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 
-import net.jcip.annotations.NotThreadSafe;
+import static com.google.common.base.Predicates.compose;
+import static com.google.common.base.Predicates.equalTo;
+import static com.google.common.base.Predicates.not;
+import static java.util.Collections.singletonList;
+import static java.util.stream.Collectors.toSet;
+import static org.alfasoftware.morf.metadata.DataSetUtils.dataSetProducer;
+import static org.alfasoftware.morf.metadata.DataSetUtils.record;
+import static org.alfasoftware.morf.metadata.SchemaUtils.column;
+import static org.alfasoftware.morf.metadata.SchemaUtils.copy;
+import static org.alfasoftware.morf.metadata.SchemaUtils.idColumn;
+import static org.alfasoftware.morf.metadata.SchemaUtils.index;
+import static org.alfasoftware.morf.metadata.SchemaUtils.schema;
+import static org.alfasoftware.morf.metadata.SchemaUtils.table;
+import static org.alfasoftware.morf.metadata.SchemaUtils.view;
+import static org.alfasoftware.morf.sql.SqlUtils.field;
+import static org.alfasoftware.morf.sql.SqlUtils.insert;
+import static org.alfasoftware.morf.sql.SqlUtils.literal;
+import static org.alfasoftware.morf.sql.SqlUtils.select;
+import static org.alfasoftware.morf.sql.SqlUtils.tableRef;
+import static org.alfasoftware.morf.upgrade.db.DatabaseUpgradeTableContribution.deployedViewsTable;
+import static org.alfasoftware.morf.upgrade.db.DatabaseUpgradeTableContribution.upgradeAuditTable;
+import static org.hamcrest.Matchers.equalToIgnoringCase;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 /**
  * Tests that the various SQL statement representations can be converted by the
@@ -147,6 +146,8 @@ public class TestDatabaseUpgradeIntegration {
 
   /***/
   @Rule public InjectMembersRule injectMembersRule = new InjectMembersRule(new TestingDataSourceModule());
+
+  @Rule public LocaleRule localeRule = new LocaleRule(Locale.UK);
 
   @Inject
   private Provider<DatabaseDataSetConsumer> databaseDataSetConsumer;


### PR DESCRIPTION
A minor change to ‘TestDatabaseUpgradeIntegration‘ explicitly setting the LocaleRule to ‘UK’ due to the issues reported under WEB-116913. Discussed with Anuj.