### PR TITLE
SqlDialect clean-up, refactors, improvements for future improvements

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -693,8 +693,7 @@ public abstract class SqlDialect {
 
 
   /**
-   * @return The schema prefix (including the dot) or blank if the schema's
-   *         blank.
+   * @return The schema prefix (including the dot) or blank if the schema's blank.
    */
   public String schemaNamePrefix() {
     if (StringUtils.isEmpty(schemaName)) {
@@ -705,11 +704,15 @@ public abstract class SqlDialect {
   }
 
 
+  protected String schemaNamePrefix(@SuppressWarnings("unused") Table tableRef) {
+    return schemaNamePrefix();
+  }
+
+
   /**
    * @param tableRef The table reference from which the schema name will be extracted
    * @return The schema prefix of the specified table (including the dot), the
-   *         dialect's schema prefix or blank if neither is specified (in that
-   *         order).
+   *         dialect's schema prefix or blank if neither is specified (in that order).
    */
   protected String schemaNamePrefix(TableReference tableRef) {
     if (StringUtils.isEmpty(tableRef.getSchemaName())) {
@@ -3312,11 +3315,6 @@ public abstract class SqlDialect {
       nameColumn, valueColumn, autoNumberName, getExistingMaxAutoNumberValue(dataTable, generatedFieldName)));
 
     return sql;
-  }
-
-
-  protected String schemaNamePrefix(@SuppressWarnings("unused") Table tableRef) {
-    return schemaNamePrefix();
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -727,7 +727,9 @@ public abstract class SqlDialect {
    * @param table The table to drop
    * @return The SQL statements as strings.
    */
-  public abstract Collection<String> dropStatements(Table table);
+  public Collection<String> dropStatements(Table table) {
+    return ImmutableList.of("DROP TABLE " + schemaNamePrefix(table) + table.getName());
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -2302,7 +2302,9 @@ public abstract class SqlDialect {
    * @param function the function to convert.
    * @return a string representation of the SQL.
    */
-  protected abstract String getSqlForIsNull(Function function);
+  protected String getSqlForIsNull(Function function) {
+    return "COALESCE(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -2300,7 +2300,36 @@ public abstract class SqlDialect {
    * @param scale the column scale.
    * @return a string representation of the column definition.
    */
-  protected abstract String getColumnRepresentation(DataType dataType, int width, int scale);
+  protected String getColumnRepresentation(DataType dataType, int width, int scale) {
+    switch (dataType) {
+      case STRING:
+        return width == 0 ? "VARCHAR" : String.format("VARCHAR(%d)", width);
+
+      case DECIMAL:
+        return width == 0 ? "DECIMAL" : String.format("DECIMAL(%d,%d)", width, scale);
+
+      case DATE:
+        return "DATE";
+
+      case BOOLEAN:
+        return "BIT";
+
+      case BIG_INTEGER:
+        return "BIGINT";
+
+      case INTEGER:
+        return "INTEGER";
+
+      case BLOB:
+        return "BLOB";
+
+      case CLOB:
+        return "CLOB";
+
+      default:
+        throw new UnsupportedOperationException("Cannot map column with type [" + dataType + "]");
+    }
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -244,7 +244,9 @@ public abstract class SqlDialect {
    * @param toIndexName The new index name
    * @return SQL Statements required to rename an index
    */
-  public abstract Collection<String> renameIndexStatements(Table table, String fromIndexName, String toIndexName);
+  public Collection<String> renameIndexStatements(@SuppressWarnings("unused") Table table, String fromIndexName, String toIndexName) {
+    return ImmutableList.of("ALTER INDEX " + schemaNamePrefix() + fromIndexName + " RENAME TO " + toIndexName);
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -233,7 +233,9 @@ public abstract class SqlDialect {
    * @param to - table with new name
    * @return SQL statements required to change a table name.
    */
-  public abstract Collection<String> renameTableStatements(Table from, Table to);
+  public Collection<String> renameTableStatements(Table from, Table to) {
+    return ImmutableList.of("ALTER TABLE " + schemaNamePrefix() + from.getName() + " RENAME TO " + to.getName());
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -3898,7 +3898,9 @@ public abstract class SqlDialect {
    * @param table the table for which to rebuild triggers
    * @return a collection of sql statements to execute
    */
-  public abstract Collection<String> rebuildTriggers(Table table);
+  public Collection<String> rebuildTriggers(@SuppressWarnings("unused") Table table) {
+    return SqlDialect.NO_STATEMENTS;
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -3460,7 +3460,9 @@ public abstract class SqlDialect {
    * @param table The table to run the analysis on.
    * @return The SQL statements to analyse the table.
    */
-  public abstract Collection<String> getSqlForAnalyseTable(Table table);
+  public Collection<String> getSqlForAnalyseTable(@SuppressWarnings("unused") Table table) {
+    return SqlDialect.NO_STATEMENTS;
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -3914,10 +3914,14 @@ public abstract class SqlDialect {
 
 
    /**
+   * Indicates whether the dialect supports window functions.
+   *
    * @return true if the dialect supports window functions (e.g. PARTITION BY).
    *
    **/
-   public abstract boolean supportsWindowFunctions();
+   public boolean supportsWindowFunctions() {
+     return false;
+   }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -1692,7 +1692,14 @@ public abstract class SqlDialect {
    * @param concatenatedField the field to generate SQL for
    * @return a string representation of the field literal
    */
-  protected abstract String getSqlFrom(ConcatenatedField concatenatedField);
+  protected String getSqlFrom(ConcatenatedField concatenatedField) {
+    List<String> sql = new ArrayList<>();
+    for (AliasedField field : concatenatedField.getConcatenationFields()) {
+      // Interpret null values as empty strings
+      sql.add("COALESCE(" + getSqlFrom(field) + ",'')");
+    }
+    return StringUtils.join(sql, " || ");
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -2303,7 +2303,7 @@ public abstract class SqlDialect {
    * @return a string representation of the SQL.
    */
   protected String getSqlForIsNull(Function function) {
-    return "COALESCE(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
+    return getSqlForCoalesce(function);
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -234,7 +234,7 @@ public abstract class SqlDialect {
    * @return SQL statements required to change a table name.
    */
   public Collection<String> renameTableStatements(Table from, Table to) {
-    return ImmutableList.of("ALTER TABLE " + schemaNamePrefix() + from.getName() + " RENAME TO " + to.getName());
+    return ImmutableList.of("ALTER TABLE " + schemaNamePrefix(from) + from.getName() + " RENAME TO " + to.getName());
   }
 
 
@@ -246,8 +246,8 @@ public abstract class SqlDialect {
    * @param toIndexName The new index name
    * @return SQL Statements required to rename an index
    */
-  public Collection<String> renameIndexStatements(@SuppressWarnings("unused") Table table, String fromIndexName, String toIndexName) {
-    return ImmutableList.of("ALTER INDEX " + schemaNamePrefix() + fromIndexName + " RENAME TO " + toIndexName);
+  public Collection<String> renameIndexStatements(Table table, String fromIndexName, String toIndexName) {
+    return ImmutableList.of("ALTER INDEX " + schemaNamePrefix(table) + fromIndexName + " RENAME TO " + toIndexName);
   }
 
 
@@ -267,7 +267,7 @@ public abstract class SqlDialect {
    * @return SQL statements required to clear the table.
    */
   public Collection<String> deleteAllFromTableStatements(Table table) {
-    return ImmutableList.of("DELETE FROM " + schemaNamePrefix() + table.getName());
+    return ImmutableList.of("DELETE FROM " + schemaNamePrefix(table) + table.getName());
   }
 
 
@@ -704,6 +704,10 @@ public abstract class SqlDialect {
   }
 
 
+  /**
+   * @param table The table for which the schema name will be retrieved
+   * @return Base implementation calls {@link #schemaNamePrefix()}.
+   */
   protected String schemaNamePrefix(@SuppressWarnings("unused") Table tableRef) {
     return schemaNamePrefix();
   }
@@ -3592,10 +3596,10 @@ public abstract class SqlDialect {
       statement.append("UNIQUE ");
     }
     statement.append("INDEX ")
-      .append(schemaNamePrefix())
+      .append(schemaNamePrefix(table))
       .append(index.getName())
       .append(" ON ")
-      .append(schemaNamePrefix())
+      .append(schemaNamePrefix(table))
       .append(table.getName())
       .append(" (")
       .append(Joiner.on(", ").join(index.columnNames()))

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -33,7 +33,6 @@ import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedList;
@@ -131,7 +130,7 @@ public abstract class SqlDialect {
   /**
    * Empty collection of strings that implementations can return if required.
    */
-  public static final Collection<String> NO_STATEMENTS                     = Collections.emptyList();
+  public static final Collection<String> NO_STATEMENTS                     = ImmutableList.of();
 
   /**
    * Used as the alias for the select statement in merge statements.
@@ -281,7 +280,7 @@ public abstract class SqlDialect {
    */
   @SuppressWarnings("unused")
   public Collection<String> preInsertWithPresetAutonumStatements(Table table, boolean insertingUnderAutonumLimit) {
-    return Collections.emptyList();
+    return ImmutableList.of();
   }
 
 
@@ -345,16 +344,16 @@ public abstract class SqlDialect {
       }
     } else if (statement instanceof UpdateStatement) {
       UpdateStatement update = (UpdateStatement) statement;
-      return Collections.singletonList(convertStatementToSQL(update));
+      return ImmutableList.of(convertStatementToSQL(update));
     } else if (statement instanceof DeleteStatement) {
       DeleteStatement delete = (DeleteStatement) statement;
-      return Collections.singletonList(convertStatementToSQL(delete));
+      return ImmutableList.of(convertStatementToSQL(delete));
     } else if (statement instanceof TruncateStatement) {
       TruncateStatement truncateStatement = (TruncateStatement) statement;
-      return Collections.singletonList(convertStatementToSQL(truncateStatement));
+      return ImmutableList.of(convertStatementToSQL(truncateStatement));
     } else if (statement instanceof MergeStatement) {
       MergeStatement merge = (MergeStatement) statement;
-      return Collections.singletonList(convertStatementToSQL(merge));
+      return ImmutableList.of(convertStatementToSQL(merge));
     } else {
       throw new UnsupportedOperationException("Executed statement operation not supported for [" + statement.getClass() + "]");
     }
@@ -3604,7 +3603,7 @@ public abstract class SqlDialect {
       .append(Joiner.on(", ").join(index.columnNames()))
       .append(')');
 
-    return Collections.singletonList(statement.toString());
+    return ImmutableList.of(statement.toString());
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -222,7 +222,9 @@ public abstract class SqlDialect {
    * @return SQL statements required to clear a table and prepare it for data
    *         population.
    */
-  public abstract Collection<String> truncateTableStatements(Table table);
+  public Collection<String> truncateTableStatements(Table table) {
+    return ImmutableList.of("TRUNCATE TABLE " + schemaNamePrefix(table) + table.getName());
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -32,7 +32,6 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -733,7 +732,9 @@ public abstract class SqlDialect {
    * @param view The view to drop
    * @return The SQL statements as strings.
    */
-  public abstract Collection<String> dropStatements(View view);
+  public Collection<String> dropStatements(View view) {
+    return ImmutableList.of("DROP VIEW " + schemaNamePrefix() + view.getName() + " IF EXISTS CASCADE");
+  }
 
 
   /**
@@ -3500,7 +3501,7 @@ public abstract class SqlDialect {
    * @return The SQL to drop the specified index.
    */
   public Collection<String> indexDropStatements(@SuppressWarnings("unused") Table table, Index indexToBeRemoved) {
-    return Arrays.asList("DROP INDEX " + indexToBeRemoved.getName());
+    return ImmutableList.of("DROP INDEX " + indexToBeRemoved.getName());
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -708,7 +708,7 @@ public abstract class SqlDialect {
    * @param table The table for which the schema name will be retrieved
    * @return Base implementation calls {@link #schemaNamePrefix()}.
    */
-  protected String schemaNamePrefix(@SuppressWarnings("unused") Table tableRef) {
+  protected String schemaNamePrefix(@SuppressWarnings("unused") Table table) {
     return schemaNamePrefix();
   }
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -265,7 +265,9 @@ public abstract class SqlDialect {
    * @param table the database table to clear
    * @return SQL statements required to clear the table.
    */
-  public abstract Collection<String> deleteAllFromTableStatements(Table table);
+  public Collection<String> deleteAllFromTableStatements(Table table) {
+    return ImmutableList.of("DELETE FROM " + schemaNamePrefix() + table.getName());
+  }
 
 
   /**

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -305,6 +305,15 @@ public class MockDialect extends SqlDialect {
 
 
   /**
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForNow(org.alfasoftware.morf.sql.element.Function)
+   */
+  @Override
+  protected String getSqlForNow(Function function) {
+    return "NOW()";
+  }
+
+
+  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForYYYYMMDDToDate(org.alfasoftware.morf.sql.element.Function)
    */
   @Override
@@ -329,15 +338,6 @@ public class MockDialect extends SqlDialect {
   @Override
   protected String getSqlForDateToYyyymmddHHmmss(Function function) {
     return "TO_NUMBER(TO_CHAR(" + getSqlFrom(function.getArguments().get(0)) + ", 'yyyymmddHH24MISS'))";
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForNow(org.alfasoftware.morf.sql.element.Function)
-   */
-  @Override
-  protected String getSqlForNow(Function function) {
-    return "NOW()";
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -433,7 +433,7 @@ public class MockDialect extends SqlDialect {
    */
   @Override
   protected String getSqlForRandomString(Function function) {
-    return String.format("SUBSTRING(REPLACE(RANDOM_UUID(),'-'), 1, %s)", getSqlFrom(function.getArguments().get(0)));
+    return "SUBSTRING(MD5(RAND()), 1, " + getSqlFrom(function.getArguments().get(0)) + ")";
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -33,7 +33,7 @@ import org.apache.commons.lang3.StringUtils;
 import com.google.common.base.Joiner;
 
 /**
- * Dialect, loosely based on H2, to give tests something vaguely realistic to work with.
+ * Mock {@link SqlDialect} to give tests something vaguely realistic to work with.
  *
  * @author Copyright (c) Alfa Financial Software 2017
  */
@@ -65,7 +65,7 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#tableDeploymentStatements(org.alfasoftware.morf.metadata.Table)
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#internalTableDeploymentStatements(org.alfasoftware.morf.metadata.Table)
    */
   @Override
   public Collection<String> internalTableDeploymentStatements(Table table) {
@@ -210,27 +210,18 @@ public class MockDialect extends SqlDialect {
   }
 
 
-  /**
-   * @param table The table to add the constraint for
-   * @param primaryKeyColumnNames
-   * @return The statement
-   */
   private String addPrimaryKeyConstraintStatement(Table table, List<String> primaryKeyColumnNames) {
     return "ALTER TABLE " + schemaNamePrefix() + table.getName() + " ADD CONSTRAINT " + table.getName() + "_PK PRIMARY KEY (" + Joiner.on(", ").join(primaryKeyColumnNames) + ")";
   }
 
 
-  /**
-   * @param table The table whose primary key should be dropped
-   * @return The statement
-   */
   private String dropPrimaryKeyConstraintStatement(Table table) {
     return "ALTER TABLE " + schemaNamePrefix() + table.getName() + " DROP PRIMARY KEY";
   }
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForRandomString(int)
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForRandomString(org.alfasoftware.morf.sql.element.Function)
    */
   @Override
   protected String getSqlForRandomString(Function function) {
@@ -276,8 +267,7 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForDaysBetween(org.alfasoftware.morf.sql.element.AliasedField,
-   *      org.alfasoftware.morf.sql.element.AliasedField)
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForDaysBetween(org.alfasoftware.morf.sql.element.AliasedField, org.alfasoftware.morf.sql.element.AliasedField)
    */
   @Override
   protected String getSqlForDaysBetween(AliasedField toDate, AliasedField fromDate) {
@@ -313,7 +303,7 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForLastDayOfMonth
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForLastDayOfMonth(org.alfasoftware.morf.sql.element.AliasedField)
    */
   @Override
   protected String getSqlForLastDayOfMonth(AliasedField date) {

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -26,7 +26,6 @@ import java.util.Collections;
 import java.util.List;
 
 import org.alfasoftware.morf.metadata.Column;
-import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.metadata.Table;
 import org.alfasoftware.morf.sql.element.AliasedField;
 import org.alfasoftware.morf.sql.element.Function;
@@ -145,43 +144,6 @@ public class MockDialect extends SqlDialect {
   @Override
   public Collection<String> deleteAllFromTableStatements(Table table) {
     return Arrays.asList("delete from " + table.getName());
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getColumnRepresentation(org.alfasoftware.morf.metadata.DataType,
-   *      int, int)
-   */
-  @Override
-  protected String getColumnRepresentation(DataType dataType, int width, int scale) {
-    switch (dataType) {
-      case STRING:
-        return String.format("VARCHAR(%d)", width);
-
-      case DECIMAL:
-        return String.format("DECIMAL(%d,%d)", width, scale);
-
-      case DATE:
-        return "DATE";
-
-      case BOOLEAN:
-        return "BIT";
-
-      case BIG_INTEGER:
-        return "BIGINT";
-
-      case INTEGER:
-        return "INTEGER";
-
-      case BLOB:
-        return "LONGVARBINARY";
-
-      case CLOB:
-        return "NCLOB";
-
-      default:
-        throw new UnsupportedOperationException("Cannot map column with type [" + dataType + "]");
-    }
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -289,12 +289,11 @@ public class MockDialect extends SqlDialect {
     List<String> result = new ArrayList<>();
 
     if (!oldPrimaryKeyColumns.isEmpty()) {
-      result.add("ALTER TABLE " + table.getName() + " DROP PRIMARY KEY");
+      result.add(dropPrimaryKeyConstraintStatement(table));
     }
 
     if (!newPrimaryKeyColumns.isEmpty()) {
-      result.add(
-        addPrimaryKeyConstraintStatement(table, newPrimaryKeyColumns));
+      result.add(addPrimaryKeyConstraintStatement(table, newPrimaryKeyColumns));
     }
 
     return result;
@@ -307,7 +306,7 @@ public class MockDialect extends SqlDialect {
    * @return The statement
    */
   private String addPrimaryKeyConstraintStatement(Table table, List<String> primaryKeyColumnNames) {
-    return "ALTER TABLE " + table.getName() + " ADD CONSTRAINT " + table.getName() + "_PK PRIMARY KEY (" + Joiner.on(", ").join(primaryKeyColumnNames) + ")";
+    return "ALTER TABLE " + schemaNamePrefix() + table.getName() + " ADD CONSTRAINT " + table.getName() + "_PK PRIMARY KEY (" + Joiner.on(", ").join(primaryKeyColumnNames) + ")";
   }
 
 
@@ -316,7 +315,7 @@ public class MockDialect extends SqlDialect {
    * @return The statement
    */
   private String dropPrimaryKeyConstraintStatement(Table table) {
-    return "ALTER TABLE " + table.getName() + " DROP CONSTRAINT " + table.getName() + "_PK";
+    return "ALTER TABLE " + schemaNamePrefix() + table.getName() + " DROP PRIMARY KEY";
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -28,7 +28,6 @@ import java.util.List;
 import org.alfasoftware.morf.metadata.Column;
 import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.metadata.Table;
-import org.alfasoftware.morf.metadata.View;
 import org.alfasoftware.morf.sql.element.AliasedField;
 import org.alfasoftware.morf.sql.element.ConcatenatedField;
 import org.alfasoftware.morf.sql.element.Function;
@@ -318,15 +317,6 @@ public class MockDialect extends SqlDialect {
    */
   private String dropPrimaryKeyConstraintStatement(Table table) {
     return "ALTER TABLE " + table.getName() + " DROP CONSTRAINT " + table.getName() + "_PK";
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#dropStatements(org.alfasoftware.morf.metadata.View)
-   */
-  @Override
-  public Collection<String> dropStatements(View view) {
-    return Arrays.asList("DROP VIEW " + view.getName() + " IF EXISTS CASCADE");
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -468,15 +468,6 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#supportsWindowFunctions()
-   */
-  @Override
-  public boolean supportsWindowFunctions() {
-    return false;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForAnalyseTable
    */
   @Override

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -130,15 +130,6 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#truncateTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> truncateTableStatements(Table table) {
-    return Arrays.asList("truncate table " + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#alterTableAddColumnStatements(org.alfasoftware.morf.metadata.Table, org.alfasoftware.morf.metadata.Column)
    */
   @Override

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -27,7 +27,6 @@ import java.util.List;
 
 import org.alfasoftware.morf.metadata.Column;
 import org.alfasoftware.morf.metadata.DataType;
-import org.alfasoftware.morf.metadata.Index;
 import org.alfasoftware.morf.metadata.Table;
 import org.alfasoftware.morf.metadata.View;
 import org.alfasoftware.morf.sql.element.AliasedField;
@@ -45,16 +44,6 @@ import com.google.common.collect.ImmutableList.Builder;
  * @author Copyright (c) Alfa Financial Software 2017
  */
 public class MockDialect extends SqlDialect {
-
-  /**
-   * The prefix to add to all temporary tables.
-   */
-  public static final String TEMPORARY_TABLE_PREFIX = "TEMP_";
-
-  /**
-   * Used as the alias for the select statement in merge statements.
-   */
-  private static final String MERGE_SOURCE_ALIAS = "xmergesource";
 
   private final DatabaseType databaseType = mock(DatabaseType.class);
 
@@ -179,24 +168,6 @@ public class MockDialect extends SqlDialect {
       default:
         throw new UnsupportedOperationException("Cannot map column with type [" + dataType + "]");
     }
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#useInsertBatching()
-   */
-  @Override
-  public boolean useInsertBatching() {
-    return true;
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getFromDummyTable()
-   */
-  @Override
-  protected String getFromDummyTable() {
-    return " FROM dual";
   }
 
 
@@ -349,63 +320,6 @@ public class MockDialect extends SqlDialect {
    */
   private String dropPrimaryKeyConstraintStatement(Table table) {
     return "ALTER TABLE " + table.getName() + " DROP CONSTRAINT " + table.getName() + "_PK";
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#indexDeploymentStatements(org.alfasoftware.morf.metadata.Table,
-   *      org.alfasoftware.morf.metadata.Index)
-   */
-  @Override
-  protected Collection<String> indexDeploymentStatements(Table table, Index index) {
-    StringBuilder statement = new StringBuilder();
-
-    statement.append("CREATE ");
-    if (index.isUnique()) {
-      statement.append("UNIQUE ");
-    }
-    statement.append("INDEX ").append(index.getName()).append(" ON ").append(table.getName()).append(" (")
-        .append(Joiner.on(',').join(index.columnNames())).append(")");
-
-    return Collections.singletonList(statement.toString());
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#indexDropStatements(org.alfasoftware.morf.metadata.Table,
-   *      org.alfasoftware.morf.metadata.Index)
-   */
-  @Override
-  public Collection<String> indexDropStatements(Table table, Index indexToBeRemoved) {
-    return Arrays.asList("DROP INDEX " + indexToBeRemoved.getName());
-  }
-
-
-  /**
-   * It does explicit VARCHAR casting to avoid a HSQLDB 'feature' in which
-   * string literal values are effectively returned as CHAR (fixed width) data
-   * types rather than VARCHARs, where the length of the CHAR to hold the value
-   * is given by the maximum string length of any of the values that can be
-   * returned by the CASE statement.
-   *
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#makeStringLiteral(java.lang.String)
-   */
-  @Override
-  protected String makeStringLiteral(String literalValue) {
-    if (StringUtils.isEmpty(literalValue)) {
-      return "NULL";
-    }
-
-    return String.format("CAST(%s AS VARCHAR(%d))", super.makeStringLiteral(literalValue), literalValue.length());
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#decorateTemporaryTableName(java.lang.String)
-   */
-  @Override
-  public String decorateTemporaryTableName(String undecoratedName) {
-    return TEMPORARY_TABLE_PREFIX + undecoratedName;
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -337,8 +337,7 @@ public class MockDialect extends SqlDialect {
    */
   @Override
   protected String getSqlForYYYYMMDDToDate(Function function) {
-    AliasedField field = function.getArguments().get(0);
-    return "CAST(SUBSTRING(" + getSqlFrom(field) + ", 1, 4)||'-'||SUBSTRING(" + getSqlFrom(field) + ", 5, 2)||'-'||SUBSTRING(" + getSqlFrom(field) + ", 7, 2) AS DATE)";
+    return "TO_DATE(" + getSqlFrom(function.getArguments().get(0)) + ", 'yyyymmdd')";
   }
 
 
@@ -348,8 +347,7 @@ public class MockDialect extends SqlDialect {
    */
   @Override
   protected String getSqlForDateToYyyymmdd(Function function) {
-    String sqlExpression = getSqlFrom(function.getArguments().get(0));
-    return String.format("CAST(SUBSTRING(%1$s, 1, 4)||SUBSTRING(%1$s, 6, 2)||SUBSTRING(%1$s, 9, 2) AS INT)",sqlExpression);
+    return "TO_NUMBER(TO_CHAR(" + getSqlFrom(function.getArguments().get(0)) + ", 'yyyymmdd'))";
   }
 
 
@@ -358,9 +356,7 @@ public class MockDialect extends SqlDialect {
    */
   @Override
   protected String getSqlForDateToYyyymmddHHmmss(Function function) {
-    String sqlExpression = getSqlFrom(function.getArguments().get(0));
-    // Example for CURRENT_TIMESTAMP() -> 2015-06-23 11:25:08.11
-    return String.format("CAST(SUBSTRING(%1$s, 1, 4)||SUBSTRING(%1$s, 6, 2)||SUBSTRING(%1$s, 9, 2)||SUBSTRING(%1$s, 12, 2)||SUBSTRING(%1$s, 15, 2)||SUBSTRING(%1$s, 18, 2) AS BIGINT)", sqlExpression);
+    return "TO_NUMBER(TO_CHAR(" + getSqlFrom(function.getArguments().get(0)) + ", 'yyyymmddHH24MISS'))";
   }
 
 
@@ -369,7 +365,7 @@ public class MockDialect extends SqlDialect {
    */
   @Override
   protected String getSqlForNow(Function function) {
-    return "UTC_TIMESTAMP()";
+    return "NOW()";
   }
 
 
@@ -397,11 +393,7 @@ public class MockDialect extends SqlDialect {
    */
   @Override
   protected String getSqlForAddDays(Function function) {
-    return String.format(
-      "DATEADD('DAY', %s, %s)",
-      getSqlFrom(function.getArguments().get(1)),
-      getSqlFrom(function.getArguments().get(0))
-    );
+    return "DATEADD('DAY', " + getSqlFrom(function.getArguments().get(1)) + ", " + getSqlFrom(function.getArguments().get(0)) + ")";
   }
 
 
@@ -410,11 +402,7 @@ public class MockDialect extends SqlDialect {
    */
   @Override
   protected String getSqlForAddMonths(Function function) {
-    return String.format(
-      "DATEADD('MONTH', %s, %s)",
-      getSqlFrom(function.getArguments().get(1)),
-      getSqlFrom(function.getArguments().get(0))
-    );
+    return "DATEADD('MONTH', " + getSqlFrom(function.getArguments().get(1)) + ", " + getSqlFrom(function.getArguments().get(0)) + ")";
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -29,7 +29,6 @@ import org.alfasoftware.morf.metadata.Column;
 import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.metadata.Table;
 import org.alfasoftware.morf.sql.element.AliasedField;
-import org.alfasoftware.morf.sql.element.ConcatenatedField;
 import org.alfasoftware.morf.sql.element.Function;
 import org.apache.commons.lang3.StringUtils;
 
@@ -183,20 +182,6 @@ public class MockDialect extends SqlDialect {
   @Override
   public DatabaseType getDatabaseType() {
     return databaseType;
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlFrom(ConcatenatedField)
-   */
-  @Override
-  protected String getSqlFrom(ConcatenatedField concatenatedField) {
-    List<String> sql = new ArrayList<>();
-    for (AliasedField field : concatenatedField.getConcatenationFields()) {
-      // Interpret null values as empty strings
-      sql.add("COALESCE(" + getSqlFrom(field) + ",'')");
-    }
-    return StringUtils.join(sql, " || ");
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -20,7 +20,6 @@ import static org.alfasoftware.morf.metadata.SchemaUtils.primaryKeysForTable;
 import static org.mockito.Mockito.mock;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -117,15 +116,6 @@ public class MockDialect extends SqlDialect {
     statements.add(createTableStatement.toString());
 
     return statements;
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#dropStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> dropStatements(Table table) {
-    return Arrays.asList("drop table " + table.getName());
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -49,6 +49,24 @@ public class MockDialect extends SqlDialect {
 
 
   /**
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#getDatabaseType()
+   */
+  @Override
+  public DatabaseType getDatabaseType() {
+    return databaseType;
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#connectionTestStatement()
+   */
+  @Override
+  public String connectionTestStatement() {
+    return "select 1";
+  }
+
+
+  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#tableDeploymentStatements(org.alfasoftware.morf.metadata.Table)
    */
   @Override
@@ -164,24 +182,6 @@ public class MockDialect extends SqlDialect {
       default:
         throw new UnsupportedOperationException("Cannot map column with type [" + dataType + "]");
     }
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#connectionTestStatement()
-   */
-  @Override
-  public String connectionTestStatement() {
-    return "select 1";
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getDatabaseType()
-   */
-  @Override
-  public DatabaseType getDatabaseType() {
-    return databaseType;
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -438,15 +438,6 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#renameIndexStatements(org.alfasoftware.morf.metadata.Table, java.lang.String, java.lang.String)
-   */
-  @Override
-  public Collection<String> renameIndexStatements(Table table, String fromIndexName, String toIndexName) {
-    return ImmutableList.of(String.format("ALTER INDEX %s RENAME TO %s", fromIndexName, toIndexName));
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForLastDayOfMonth
    */
   @Override

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -201,15 +201,6 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForIsNull(org.alfasoftware.morf.sql.element.Function)
-   */
-  @Override
-  protected String getSqlForIsNull(Function function) {
-    return "COALESCE(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#alterTableAddColumnStatements(org.alfasoftware.morf.metadata.Table, org.alfasoftware.morf.metadata.Column)
    */
   @Override

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -465,13 +465,4 @@ public class MockDialect extends SqlDialect {
   protected String getSqlForLastDayOfMonth(AliasedField date) {
     return "DATEADD(dd, -DAY(DATEADD(m,1," + getSqlFrom(date) + ")), DATEADD(m,1," + getSqlFrom(date) + "))";
   }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForAnalyseTable
-   */
-  @Override
-  public Collection<String> getSqlForAnalyseTable(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -35,8 +35,6 @@ import org.alfasoftware.morf.sql.element.Function;
 import org.apache.commons.lang3.StringUtils;
 
 import com.google.common.base.Joiner;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
 
 /**
  * Dialect, loosely based on H2, to give tests something vaguely realistic to work with.
@@ -412,28 +410,6 @@ public class MockDialect extends SqlDialect {
   @Override
   protected String getSqlForAddMonths(Function function) {
     return "DATEADD('MONTH', " + getSqlFrom(function.getArguments().get(1)) + ", " + getSqlFrom(function.getArguments().get(0)) + ")";
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#renameTableStatements(java.lang.String, java.lang.String)
-   */
-  @Override
-  public Collection<String> renameTableStatements(Table from, Table to) {
-
-    Builder<String> builder = ImmutableList.<String>builder();
-
-    if (!primaryKeysForTable(from).isEmpty()) {
-      builder.add(dropPrimaryKeyConstraintStatement(from));
-    }
-
-    builder.add("ALTER TABLE " + from.getName() + " RENAME TO " + to.getName());
-
-    if (!primaryKeysForTable(to).isEmpty()) {
-      builder.add(addPrimaryKeyConstraintStatement(to, namesOfColumns(primaryKeysForTable(to))));
-    }
-
-    return builder.build();
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -388,26 +388,7 @@ public class MockDialect extends SqlDialect {
    */
   @Override
   protected String getSqlForMonthsBetween(AliasedField toDate, AliasedField fromDate) {
-    return String.format(
-       "CASE " +
-        "WHEN %1$s = %2$s THEN 0 " +
-        "ELSE " +
-         "DATEDIFF(MONTH, %1$s, %2$s) + " +
-         "CASE " +
-          "WHEN %2$s > %1$s THEN " +
-            "CASE " +
-             "WHEN DAY(%1$s) <= DAY(%2$s) OR MONTH(%2$s) <> MONTH(DATEADD(DAY, 1, %2$s)) THEN 0 " +
-             "ELSE -1 " +
-            "END " +
-          "ELSE " +
-            "CASE " +
-             "WHEN DAY(%2$s) <= DAY(%1$s) OR MONTH(%1$s) <> MONTH(DATEADD(DAY, 1, %1$s)) THEN 0 " +
-             "ELSE 1 " +
-            "END " +
-         "END " +
-       "END ",
-       getSqlFrom(fromDate), getSqlFrom(toDate)
-    );
+    return "DATEDIFF('MONTH'," + getSqlFrom(fromDate) + ", " + getSqlFrom(toDate) + ")";
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -333,6 +333,15 @@ public class MockDialect extends SqlDialect {
 
 
   /**
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForRandomString(int)
+   */
+  @Override
+  protected String getSqlForRandomString(Function function) {
+    return "SUBSTRING(MD5(RAND()), 1, " + getSqlFrom(function.getArguments().get(0)) + ")";
+  }
+
+
+  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForYYYYMMDDToDate(org.alfasoftware.morf.sql.element.Function)
    */
   @Override
@@ -425,15 +434,6 @@ public class MockDialect extends SqlDialect {
     }
 
     return builder.build();
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForRandomString(int)
-   */
-  @Override
-  protected String getSqlForRandomString(Function function) {
-    return "SUBSTRING(MD5(RAND()), 1, " + getSqlFrom(function.getArguments().get(0)) + ")";
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -459,15 +459,6 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#rebuildTriggers(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> rebuildTriggers(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForLastDayOfMonth
    */
   @Override

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/MockDialect.java
@@ -139,15 +139,6 @@ public class MockDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#deleteAllFromTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> deleteAllFromTableStatements(Table table) {
-    return Arrays.asList("delete from " + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#alterTableAddColumnStatements(org.alfasoftware.morf.metadata.Table, org.alfasoftware.morf.metadata.Column)
    */
   @Override

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestInlineTableUpgrader.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestInlineTableUpgrader.java
@@ -286,6 +286,7 @@ public class TestInlineTableUpgrader {
     UpdateStatement updateStatement = mock(UpdateStatement.class);
     given(executeStatement.getStatement()).willReturn(updateStatement);
     when(sqlDialect.convertStatementToSQL(eq((Statement)updateStatement), any(Schema.class), any(Table.class))).thenCallRealMethod();
+    when(sqlDialect.convertStatementToSQL(eq(updateStatement))).thenReturn("dummy");
 
     // when
     upgrader.visit(executeStatement);
@@ -306,6 +307,7 @@ public class TestInlineTableUpgrader {
     DeleteStatement deleteStatement = mock(DeleteStatement.class);
     given(executeStatement.getStatement()).willReturn(deleteStatement);
     when(sqlDialect.convertStatementToSQL(eq((Statement)deleteStatement), any(Schema.class), any(Table.class))).thenCallRealMethod();
+    when(sqlDialect.convertStatementToSQL(eq(deleteStatement))).thenReturn("dummy");
 
     // when
     upgrader.visit(executeStatement);
@@ -326,6 +328,7 @@ public class TestInlineTableUpgrader {
     MergeStatement mergeStatement = mock(MergeStatement.class);
     given(executeStatement.getStatement()).willReturn(mergeStatement);
     when(sqlDialect.convertStatementToSQL(eq((Statement)mergeStatement), any(Schema.class), any(Table.class))).thenCallRealMethod();
+    when(sqlDialect.convertStatementToSQL(eq(mergeStatement))).thenReturn("dummy");
 
     // when
     upgrader.visit(executeStatement);

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -652,15 +652,6 @@ class H2Dialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect.getSqlForAnalyseTable(Table)
-   */
-  @Override
-  public Collection<String> getSqlForAnalyseTable(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect.getDeleteLimitSuffixSql(int)
    */
   @Override

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -227,15 +227,6 @@ class H2Dialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForIsNull(org.alfasoftware.morf.sql.element.Function)
-   */
-  @Override
-  protected String getSqlForIsNull(Function function) {
-    return "COALESCE(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#alterTableAddColumnStatements(org.alfasoftware.morf.metadata.Table, org.alfasoftware.morf.metadata.Column)
    */
   @Override

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -315,12 +315,11 @@ class H2Dialect extends SqlDialect {
     List<String> result = new ArrayList<>();
 
     if (!oldPrimaryKeyColumns.isEmpty()) {
-      result.add("ALTER TABLE " + schemaNamePrefix() + table.getName() + " DROP PRIMARY KEY");
+      result.add(dropPrimaryKeyConstraintStatement(table));
     }
 
     if (!newPrimaryKeyColumns.isEmpty()) {
-      result.add(
-        addPrimaryKeyConstraintStatement(table, newPrimaryKeyColumns));
+      result.add(addPrimaryKeyConstraintStatement(table, newPrimaryKeyColumns));
     }
 
     return result;
@@ -342,7 +341,7 @@ class H2Dialect extends SqlDialect {
    * @return The statement
    */
   private String dropPrimaryKeyConstraintStatement(Table table) {
-    return "ALTER TABLE " + schemaNamePrefix() + table.getName() + " DROP CONSTRAINT " + table.getName() + "_PK";
+    return "ALTER TABLE " + schemaNamePrefix() + table.getName() + " DROP PRIMARY KEY";
   }
 
 

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -31,7 +31,6 @@ import org.alfasoftware.morf.metadata.Column;
 import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.metadata.Index;
 import org.alfasoftware.morf.metadata.Table;
-import org.alfasoftware.morf.metadata.View;
 import org.alfasoftware.morf.sql.MergeStatement;
 import org.alfasoftware.morf.sql.element.AliasedField;
 import org.alfasoftware.morf.sql.element.ConcatenatedField;
@@ -401,15 +400,6 @@ class H2Dialect extends SqlDialect {
   @Override
   public String decorateTemporaryTableName(String undecoratedName) {
     return TEMPORARY_TABLE_PREFIX + undecoratedName;
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#dropStatements(org.alfasoftware.morf.metadata.View)
-   */
-  @Override
-  public Collection<String> dropStatements(View view) {
-    return Arrays.asList("DROP VIEW " + schemaNamePrefix() + view.getName() + " IF EXISTS CASCADE");
   }
 
 

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -139,15 +139,6 @@ class H2Dialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#deleteAllFromTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> deleteAllFromTableStatements(Table table) {
-    return Arrays.asList("delete from " + schemaNamePrefix() + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getColumnRepresentation(org.alfasoftware.morf.metadata.DataType,
    *      int, int)
    */

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -33,7 +33,6 @@ import org.alfasoftware.morf.metadata.Index;
 import org.alfasoftware.morf.metadata.Table;
 import org.alfasoftware.morf.sql.MergeStatement;
 import org.alfasoftware.morf.sql.element.AliasedField;
-import org.alfasoftware.morf.sql.element.ConcatenatedField;
 import org.alfasoftware.morf.sql.element.Function;
 import org.alfasoftware.morf.sql.element.SqlParameter;
 import org.alfasoftware.morf.sql.element.WindowFunction;
@@ -209,20 +208,6 @@ class H2Dialect extends SqlDialect {
   @Override
   public DatabaseType getDatabaseType() {
     return DatabaseType.Registry.findByIdentifier(H2.IDENTIFIER);
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlFrom(ConcatenatedField)
-   */
-  @Override
-  protected String getSqlFrom(ConcatenatedField concatenatedField) {
-    List<String> sql = new ArrayList<>();
-    for (AliasedField field : concatenatedField.getConcatenationFields()) {
-      // Interpret null values as empty strings
-      sql.add("COALESCE(" + getSqlFrom(field) + ",'')");
-    }
-    return StringUtils.join(sql, " || ");
   }
 
 

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -625,15 +625,6 @@ class H2Dialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#supportsWindowFunctions()
-   */
-  @Override
-  public boolean supportsWindowFunctions() {
-    return false;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlFrom(org.alfasoftware.morf.sql.element.WindowFunction)
    */
   @Override

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -130,15 +130,6 @@ class H2Dialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#truncateTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> truncateTableStatements(Table table) {
-    return Arrays.asList("truncate table " + schemaNamePrefix() + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getColumnRepresentation(org.alfasoftware.morf.metadata.DataType,
    *      int, int)
    */

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -634,15 +634,6 @@ class H2Dialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#renameIndexStatements(org.alfasoftware.morf.metadata.Table, java.lang.String, java.lang.String)
-   */
-  @Override
-  public Collection<String> renameIndexStatements(Table table, String fromIndexName, String toIndexName) {
-    return ImmutableList.of(String.format("ALTER INDEX %s RENAME TO %s", fromIndexName, toIndexName));
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForLastDayOfMonth
    */
   @Override

--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2Dialect.java
@@ -652,15 +652,6 @@ class H2Dialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#rebuildTriggers(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> rebuildTriggers(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForLastDayOfMonth
    */
   @Override

--- a/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
+++ b/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
@@ -1054,6 +1054,15 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedRenameIndexStatements() {
+    return ImmutableList.of("ALTER INDEX TESTSCHEMA.Test_1 RENAME TO Test_2");
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRenameIndexStatements()
+   */
+  @Override
+  protected List<String> expectedRenameTempIndexStatements() {
     return ImmutableList.of("ALTER INDEX TESTSCHEMA.TempTest_1 RENAME TO TempTest_2");
   }
 

--- a/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
+++ b/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
@@ -673,7 +673,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
   @Override
   protected List<String> expectedAlterRemoveColumnFromCompositeKeyStatements() {
     return ImmutableList.of(
-      "ALTER TABLE TESTSCHEMA.CompositePrimaryKey DROP CONSTRAINT CompositePrimaryKey_PK",
+      "ALTER TABLE TESTSCHEMA.CompositePrimaryKey DROP PRIMARY KEY",
       "ALTER TABLE TESTSCHEMA.CompositePrimaryKey ALTER COLUMN secondPrimaryKey SET NULL",
       "ALTER TABLE TESTSCHEMA.CompositePrimaryKey ALTER COLUMN secondPrimaryKey VARCHAR(5)",
       "ALTER TABLE TESTSCHEMA.CompositePrimaryKey ADD CONSTRAINT CompositePrimaryKey_PK PRIMARY KEY (id)"
@@ -1030,7 +1030,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
   @Override
   protected List<String> expectedRenameTableStatements() {
     return ImmutableList.of(
-      "ALTER TABLE TESTSCHEMA.Test DROP CONSTRAINT Test_PK",
+      "ALTER TABLE TESTSCHEMA.Test DROP PRIMARY KEY",
       "ALTER TABLE TESTSCHEMA.Test RENAME TO Renamed",
       "ALTER TABLE TESTSCHEMA.Renamed ADD CONSTRAINT Renamed_PK PRIMARY KEY (id)"
     );
@@ -1043,7 +1043,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
   @Override
   protected List<String> getRenamingTableWithLongNameStatements() {
     return ImmutableList.of(
-      "ALTER TABLE TESTSCHEMA.123456789012345678901234567890XXX DROP CONSTRAINT 123456789012345678901234567890XXX_PK",
+      "ALTER TABLE TESTSCHEMA.123456789012345678901234567890XXX DROP PRIMARY KEY",
       "ALTER TABLE TESTSCHEMA.123456789012345678901234567890XXX RENAME TO Blah",
       "ALTER TABLE TESTSCHEMA.Blah ADD CONSTRAINT Blah_PK PRIMARY KEY (id)");
   }

--- a/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
+++ b/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
@@ -116,7 +116,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedTruncateTableStatements() {
-    return Arrays.asList("truncate table TESTSCHEMA.Test");
+    return Arrays.asList("TRUNCATE TABLE TESTSCHEMA.Test");
   }
 
 
@@ -125,7 +125,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedTruncateTempTableStatements() {
-    return Arrays.asList("truncate table TESTSCHEMA.TEMP_TempTest");
+    return Arrays.asList("TRUNCATE TABLE TESTSCHEMA.TEMP_TempTest");
   }
 
 

--- a/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
+++ b/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
@@ -134,7 +134,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedDeleteAllFromTableStatements() {
-    return Arrays.asList("delete from TESTSCHEMA.Test");
+    return Arrays.asList("DELETE FROM TESTSCHEMA.Test");
   }
 
 

--- a/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
+++ b/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
@@ -1054,7 +1054,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedRenameIndexStatements() {
-    return ImmutableList.of("ALTER INDEX TempTest_1 RENAME TO TempTest_2");
+    return ImmutableList.of("ALTER INDEX TESTSCHEMA.TempTest_1 RENAME TO TempTest_2");
   }
 
 

--- a/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
+++ b/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
@@ -285,7 +285,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedIsNull() {
-    return "COALESCE(CAST('A' AS VARCHAR(1)), CAST('B' AS VARCHAR(1))) ";
+    return "COALESCE(CAST('A' AS VARCHAR(1)), CAST('B' AS VARCHAR(1)))";
   }
 
 

--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
@@ -487,15 +487,6 @@ class MySqlDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForIsNull(org.alfasoftware.morf.sql.element.Function)
-   */
-  @Override
-  protected String getSqlForIsNull(Function function) {
-    return "COALESCE(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getFromDummyTable()
    */
   @Override

--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
@@ -871,15 +871,6 @@ class MySqlDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#supportsWindowFunctions()
-   */
-  @Override
-  public boolean supportsWindowFunctions() {
-    return false;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlFrom(org.alfasoftware.morf.sql.element.WindowFunction)
    */
   @Override

--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
@@ -298,15 +298,6 @@ class MySqlDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#deleteAllFromTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> deleteAllFromTableStatements(Table table) {
-    return Arrays.asList("delete from " + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#postInsertWithPresetAutonumStatements(org.alfasoftware.morf.metadata.Table, boolean)
    */
   @Override

--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
@@ -871,15 +871,6 @@ class MySqlDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#rebuildTriggers(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> rebuildTriggers(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#supportsWindowFunctions()
    */
   @Override

--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
@@ -917,15 +917,6 @@ class MySqlDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect.getSqlForAnalyseTable(Table)
-   */
-  @Override
-  public Collection<String> getSqlForAnalyseTable(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect.getDeleteLimitSuffixSql(int)
    */
   @Override

--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
@@ -289,15 +289,6 @@ class MySqlDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#truncateTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> truncateTableStatements(Table table) {
-    return Arrays.asList("TRUNCATE " + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#postInsertWithPresetAutonumStatements(org.alfasoftware.morf.metadata.Table, boolean)
    */
   @Override

--- a/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
+++ b/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
@@ -182,7 +182,7 @@ public class TestMySqlDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedDeleteAllFromTableStatements() {
-    return Arrays.asList("delete from Test");
+    return Arrays.asList("DELETE FROM Test");
   }
 
 

--- a/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
+++ b/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
@@ -164,7 +164,7 @@ public class TestMySqlDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedTruncateTableStatements() {
-    return Arrays.asList("TRUNCATE Test");
+    return Arrays.asList("TRUNCATE TABLE Test");
   }
 
 
@@ -173,7 +173,7 @@ public class TestMySqlDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedTruncateTempTableStatements() {
-    return Arrays.asList("TRUNCATE TempTest");
+    return Arrays.asList("TRUNCATE TABLE TempTest");
   }
 
 

--- a/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
+++ b/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
@@ -1075,6 +1075,18 @@ public class TestMySqlDialect extends AbstractSqlDialectTest {
   @Override
   protected List<String> expectedRenameIndexStatements() {
     return ImmutableList.of(
+      "ALTER TABLE `Test` DROP INDEX `Test_1`",
+      "ALTER TABLE `Test` ADD INDEX `Test_2` (`intField`, `floatField`)"
+    );
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRenameIndexStatements()
+   */
+  @Override
+  protected List<String> expectedRenameTempIndexStatements() {
+    return ImmutableList.of(
       "ALTER TABLE `TempTest` DROP INDEX `TempTest_1`",
       "ALTER TABLE `TempTest` ADD INDEX `TempTest_2` (`intField`, `floatField`)"
     );

--- a/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
+++ b/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
@@ -373,7 +373,7 @@ public class TestMySqlDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedIsNull() {
-    return "COALESCE('A', 'B') ";
+    return "COALESCE('A', 'B')";
   }
 
 

--- a/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
+++ b/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
@@ -894,15 +894,6 @@ class NuoDBDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#rebuildTriggers(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> rebuildTriggers(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#likeEscapeSuffix()
    */
   @Override

--- a/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
+++ b/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
@@ -40,7 +40,6 @@ import org.alfasoftware.morf.metadata.Column;
 import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.metadata.Index;
 import org.alfasoftware.morf.metadata.Table;
-import org.alfasoftware.morf.metadata.View;
 import org.alfasoftware.morf.sql.Hint;
 import org.alfasoftware.morf.sql.MergeStatement;
 import org.alfasoftware.morf.sql.SelectStatement;
@@ -687,15 +686,6 @@ class NuoDBDialect extends SqlDialect {
   @Override
   public String decorateTemporaryTableName(String undecoratedName) {
     return TEMPORARY_TABLE_PREFIX + undecoratedName;
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#dropStatements(org.alfasoftware.morf.metadata.View)
-   */
-  @Override
-  public Collection<String> dropStatements(View view) {
-    return Arrays.asList("DROP VIEW " + schemaNamePrefix() + view.getName() + " IF EXISTS CASCADE");
   }
 
 

--- a/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
+++ b/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
@@ -357,15 +357,6 @@ class NuoDBDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForIsNull(org.alfasoftware.morf.sql.element.Function)
-   */
-  @Override
-  protected String getSqlForIsNull(Function function) {
-    return "COALESCE(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#alterTableAddColumnStatements(org.alfasoftware.morf.metadata.Table, org.alfasoftware.morf.metadata.Column)
    */
   @Override

--- a/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
+++ b/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
@@ -983,15 +983,6 @@ class NuoDBDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect.getSqlForAnalyseTable(Table)
-   */
-  @Override
-  public Collection<String> getSqlForAnalyseTable(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect.getDeleteLimitSuffixSql(int)
    */
   @Override

--- a/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
+++ b/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
@@ -219,15 +219,6 @@ class NuoDBDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#truncateTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> truncateTableStatements(Table table) {
-    return Arrays.asList("truncate table " + qualifiedTableName(table));
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getColumnRepresentation(org.alfasoftware.morf.metadata.DataType,
    *      int, int)
    */

--- a/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
+++ b/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
@@ -228,15 +228,6 @@ class NuoDBDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#deleteAllFromTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> deleteAllFromTableStatements(Table table) {
-    return Arrays.asList("delete from " + qualifiedTableName(table));
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getColumnRepresentation(org.alfasoftware.morf.metadata.DataType,
    *      int, int)
    */

--- a/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
+++ b/morf-nuodb/src/main/java/org/alfasoftware/morf/jdbc/nuodb/NuoDBDialect.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Optional;
 import java.util.Set;
-import java.util.stream.Collectors;
 
 import org.alfasoftware.morf.jdbc.DatabaseType;
 import org.alfasoftware.morf.jdbc.NamedParameterPreparedStatement;
@@ -46,7 +45,6 @@ import org.alfasoftware.morf.sql.SelectStatement;
 import org.alfasoftware.morf.sql.UseImplicitJoinOrder;
 import org.alfasoftware.morf.sql.UseIndex;
 import org.alfasoftware.morf.sql.element.AliasedField;
-import org.alfasoftware.morf.sql.element.ConcatenatedField;
 import org.alfasoftware.morf.sql.element.FieldLiteral;
 import org.alfasoftware.morf.sql.element.FieldReference;
 import org.alfasoftware.morf.sql.element.Function;
@@ -339,20 +337,6 @@ class NuoDBDialect extends SqlDialect {
       default:
         return super.getSqlFrom(field);
     }
-  }
-
-
-  /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlFrom(ConcatenatedField)
-   * TODO - We don't expect the cast here to be required.
-   * Consulting with NuoDB support under WEB-73667
-   */
-  @Override
-  protected String getSqlFrom(ConcatenatedField concatenatedField) {
-    return concatenatedField.getConcatenationFields().stream()
-    .map(this::getSqlFrom)
-    .map(p -> "IFNULL(CAST(" + p + " AS STRING),'')")
-    .collect(Collectors.joining(" || "));
   }
 
 

--- a/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
+++ b/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
@@ -148,7 +148,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedTruncateTableStatements() {
-    return Arrays.asList("truncate table SCM.Test");
+    return Arrays.asList("TRUNCATE TABLE SCM.Test");
   }
 
 
@@ -157,7 +157,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedTruncateTempTableStatements() {
-    return Arrays.asList("truncate table TEMP_TempTest"); // no schema because is temporary
+    return Arrays.asList("TRUNCATE TABLE TEMP_TempTest"); // no schema because is temporary
   }
 
 

--- a/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
+++ b/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
@@ -553,7 +553,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedIsNull() {
-    return "COALESCE('A', 'B') ";
+    return "COALESCE('A', 'B')";
   }
 
 

--- a/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
+++ b/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
@@ -499,7 +499,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedConcatenationWithCase() {
-    return "SELECT IFNULL(CAST(assetDescriptionLine1 AS STRING),'') || IFNULL(CAST(CASE WHEN (taxVariationIndicator = 'Y') THEN exposureCustomerNumber ELSE invoicingCustomerNumber END AS STRING),'') AS test FROM SCM.schedule";
+    return "SELECT COALESCE(assetDescriptionLine1,'') || COALESCE(CASE WHEN (taxVariationIndicator = 'Y') THEN exposureCustomerNumber ELSE invoicingCustomerNumber END,'') AS test FROM SCM.schedule";
   }
 
 
@@ -508,7 +508,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedConcatenationWithFunction() {
-    return "SELECT IFNULL(CAST(assetDescriptionLine1 AS STRING),'') || IFNULL(CAST(MAX(scheduleStartDate) AS STRING),'') AS test FROM SCM.schedule";
+    return "SELECT COALESCE(assetDescriptionLine1,'') || COALESCE(MAX(scheduleStartDate),'') AS test FROM SCM.schedule";
   }
 
 
@@ -517,7 +517,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedConcatenationWithMultipleFieldLiterals() {
-    return "SELECT IFNULL(CAST('ABC' AS STRING),'') || IFNULL(CAST(' ' AS STRING),'') || IFNULL(CAST('DEF' AS STRING),'') AS assetDescription FROM SCM.schedule";
+    return "SELECT COALESCE('ABC','') || COALESCE(' ','') || COALESCE('DEF','') AS assetDescription FROM SCM.schedule";
   }
 
 
@@ -526,7 +526,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedNestedConcatenations() {
-    return "SELECT IFNULL(CAST(field1 AS STRING),'') || IFNULL(CAST(IFNULL(CAST(field2 AS STRING),'') || IFNULL(CAST('XYZ' AS STRING),'') AS STRING),'') AS test FROM SCM.schedule";
+    return "SELECT COALESCE(field1,'') || COALESCE(COALESCE(field2,'') || COALESCE('XYZ',''),'') AS test FROM SCM.schedule";
   }
 
 
@@ -535,7 +535,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedSelectWithConcatenation1() {
-    return "SELECT IFNULL(CAST(assetDescriptionLine1 AS STRING),'') || IFNULL(CAST(' ' AS STRING),'') || IFNULL(CAST(assetDescriptionLine2 AS STRING),'') AS assetDescription FROM SCM.schedule";
+    return "SELECT COALESCE(assetDescriptionLine1,'') || COALESCE(' ','') || COALESCE(assetDescriptionLine2,'') AS assetDescription FROM SCM.schedule";
   }
 
 
@@ -544,7 +544,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedSelectWithConcatenation2() {
-    return "SELECT IFNULL(CAST(assetDescriptionLine1 AS STRING),'') || IFNULL(CAST('XYZ' AS STRING),'') || IFNULL(CAST(assetDescriptionLine2 AS STRING),'') AS assetDescription FROM SCM.schedule";
+    return "SELECT COALESCE(assetDescriptionLine1,'') || COALESCE('XYZ','') || COALESCE(assetDescriptionLine2,'') AS assetDescription FROM SCM.schedule";
   }
 
 

--- a/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
+++ b/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
@@ -1308,6 +1308,18 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
   @Override
   protected List<String> expectedRenameIndexStatements() {
     return ImmutableList.of(
+      "DROP INDEX SCM.Test_1",
+      "CREATE INDEX Test_2 ON SCM.Test (intField,floatField)"
+    );
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRenameIndexStatements()
+   */
+  @Override
+  protected List<String> expectedRenameTempIndexStatements() {
+    return ImmutableList.of(
       "DROP INDEX TempTest_1",
       "CREATE INDEX TempTest_2 ON TEMP_TempTest (intField,floatField)" // no schema name as temporary
     );

--- a/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
+++ b/morf-nuodb/src/test/java/org/alfasoftware/morf/jdbc/nuodb/TestNuoDBDialect.java
@@ -166,7 +166,7 @@ public class TestNuoDBDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedDeleteAllFromTableStatements() {
-    return Arrays.asList("delete from SCM.Test");
+    return Arrays.asList("DELETE FROM SCM.Test");
   }
 
 

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -1060,15 +1060,6 @@ class OracleDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#renameIndexStatements(org.alfasoftware.morf.metadata.Table, java.lang.String, java.lang.String)
-   */
-  @Override
-  public Collection<String> renameIndexStatements(Table table, String fromIndexName, String toIndexName) {
-    return ImmutableList.of(String.format("ALTER INDEX %s%s RENAME TO %s", schemaNamePrefix(), fromIndexName, toIndexName));
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#addTableFromStatements(org.alfasoftware.morf.metadata.Table, org.alfasoftware.morf.sql.SelectStatement)
    */
   @Override

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -575,15 +575,6 @@ class OracleDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForIsNull(org.alfasoftware.morf.sql.element.Function)
-   */
-  @Override
-  protected String getSqlForIsNull(Function function) {
-    return "nvl(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#buildSQLToStartTracing(java.lang.String)
    */
   @Override

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -116,15 +116,6 @@ class OracleDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#deleteAllFromTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> deleteAllFromTableStatements(Table table) {
-    return Arrays.asList("delete from " + schemaNamePrefix() + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#tableDeploymentStatements(org.alfasoftware.morf.metadata.Table)
    */
   @Override

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -525,7 +525,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedIsNull() {
-    return "nvl(N'A', N'B') ";
+    return "COALESCE(N'A', N'B') ";
   }
 
 

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -525,7 +525,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedIsNull() {
-    return "COALESCE(N'A', N'B') ";
+    return "COALESCE(N'A', N'B')";
   }
 
 

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -282,7 +282,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedDeleteAllFromTableStatements() {
-    return Arrays.asList("delete from TESTSCHEMA.Test");
+    return Arrays.asList("DELETE FROM TESTSCHEMA.Test");
   }
 
 

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -1320,6 +1320,15 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedRenameIndexStatements() {
+    return ImmutableList.of("ALTER INDEX TESTSCHEMA.Test_1 RENAME TO Test_2");
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRenameIndexStatements()
+   */
+  @Override
+  protected List<String> expectedRenameTempIndexStatements() {
     return ImmutableList.of("ALTER INDEX TESTSCHEMA.TempTest_1 RENAME TO TempTest_2");
   }
 

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -257,8 +257,10 @@ class PostgreSQLDialect extends SqlDialect {
 
   @Override
   public Collection<String> renameIndexStatements(Table table, String fromIndexName, String toIndexName) {
-    return ImmutableList.of("ALTER INDEX " + schemaNamePrefix() + fromIndexName + " RENAME TO " + toIndexName,
-      addIndexComment(toIndexName));
+    return ImmutableList.<String>builder()
+        .addAll(super.renameIndexStatements(table, fromIndexName, toIndexName))
+        .add(addIndexComment(toIndexName))
+        .build();
   }
 
 

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -286,12 +286,6 @@ class PostgreSQLDialect extends SqlDialect {
 
 
   @Override
-  public Collection<String> deleteAllFromTableStatements(Table table) {
-    return ImmutableList.of("DELETE FROM " + schemaNamePrefix(table) + table.getName());
-  }
-
-
-  @Override
   public Collection<String> viewDeploymentStatements(View view) {
     return ImmutableList.<String>builder()
         .addAll(super.viewDeploymentStatements(view))

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -290,23 +290,6 @@ class PostgreSQLDialect extends SqlDialect {
 
 
   @Override
-  public Collection<String> dropStatements(Table table) {
-    ImmutableList.Builder<String> statements = ImmutableList.builder();
-
-    StringBuilder dropStatement = new StringBuilder();
-
-    dropStatement.append("DROP TABLE ");
-
-    dropStatement.append(schemaNamePrefix(table))
-                 .append(table.getName());
-
-    statements.add(dropStatement.toString());
-
-    return statements.build();
-  }
-
-
-  @Override
   public Collection<String> dropStatements(View view) {
     return ImmutableList.of("DROP VIEW IF EXISTS " + schemaNamePrefix() + view.getName() + " CASCADE");
   }

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -384,12 +384,6 @@ class PostgreSQLDialect extends SqlDialect {
 
 
   @Override
-  protected String getSqlForIsNull(Function function) {
-     return "COALESCE(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
-  }
-
-
-  @Override
   protected String getSqlForDateToYyyymmdd(Function function) {
     AliasedField field = function.getArguments().get(0);
     return "TO_CHAR("+ getSqlFrom(field) + ",'YYYYMMDD') :: NUMERIC";

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -614,12 +614,6 @@ class PostgreSQLDialect extends SqlDialect {
 
 
   @Override
-  public Collection<String> rebuildTriggers(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  @Override
   protected Collection<String> indexDeploymentStatements(Table table, Index index) {
     StringBuilder statement = new StringBuilder();
 

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -224,7 +224,7 @@ class PostgreSQLDialect extends SqlDialect {
 
     Iterable<String> renamePk = SchemaUtils.primaryKeysForTable(from).isEmpty()
         ? ImmutableList.of()
-        : renameIndexStatements(null, from.getName() + "_pk", to.getName() + "_pk");
+        : renameIndexStatements(from, from.getName() + "_pk", to.getName() + "_pk");
 
     Iterable<String> renameSeq = SchemaUtils.autoNumbersForTable(from).isEmpty()
         ? ImmutableList.of()

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -219,22 +219,6 @@ class PostgreSQLDialect extends SqlDialect {
 
 
   @Override
-  public Collection<String> truncateTableStatements(Table table) {
-    List<String> statements = new ArrayList<>();
-
-    StringBuilder truncateStatement = new StringBuilder();
-
-    truncateStatement.append("TRUNCATE TABLE ");
-
-    truncateStatement.append(schemaNamePrefix(table))
-                     .append(table.getName());
-
-    statements.add(truncateStatement.toString());
-    return statements;
-  }
-
-
-  @Override
   public Collection<String> renameTableStatements(Table from, Table to) {
     Iterable<String> renameTable = ImmutableList.of("ALTER TABLE " + schemaNamePrefix(from) + from.getName() + " RENAME TO " + to.getName());
 

--- a/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
+++ b/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
@@ -1091,6 +1091,16 @@ public class TestPostgreSQLDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedRenameIndexStatements() {
+    return ImmutableList.of("ALTER INDEX testschema.Test_1 RENAME TO Test_2",
+                            "COMMENT ON INDEX Test_2 IS 'REALNAME:[Test_2]'");
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRenameIndexStatements()
+   */
+  @Override
+  protected List<String> expectedRenameTempIndexStatements() {
     return ImmutableList.of("ALTER INDEX testschema.TempTest_1 RENAME TO TempTest_2",
                             "COMMENT ON INDEX TempTest_2 IS 'REALNAME:[TempTest_2]'");
   }

--- a/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
+++ b/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
@@ -1101,7 +1101,7 @@ public class TestPostgreSQLDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedRenameTempIndexStatements() {
-    return ImmutableList.of("ALTER INDEX testschema.TempTest_1 RENAME TO TempTest_2",
+    return ImmutableList.of("ALTER INDEX TempTest_1 RENAME TO TempTest_2",
                             "COMMENT ON INDEX TempTest_2 IS 'REALNAME:[TempTest_2]'");
   }
 

--- a/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
+++ b/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
@@ -384,7 +384,7 @@ public class TestPostgreSQLDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedIsNull() {
-    return "COALESCE('A', 'B') ";
+    return "COALESCE('A', 'B')";
   }
 
 

--- a/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
+++ b/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
@@ -220,15 +220,6 @@ class SqlServerDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#dropStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> dropStatements(Table table) {
-    return Arrays.asList("DROP TABLE " + schemaNamePrefix() + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#dropStatements(org.alfasoftware.morf.metadata.View)
    */
   @Override

--- a/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
+++ b/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
@@ -1140,15 +1140,6 @@ class SqlServerDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect.getSqlForAnalyseTable(Table)
-   */
-  @Override
-  public Collection<String> getSqlForAnalyseTable(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * @see SqlDialect#getDeleteLimitPreFromClause(int)
    */
   @Override

--- a/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
+++ b/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
@@ -420,7 +420,7 @@ class SqlServerDialect extends SqlDialect {
   protected String getSqlFrom(ConcatenatedField concatenatedField) {
     List<String> sql = new ArrayList<>();
     for (AliasedField field : concatenatedField.getConcatenationFields()) {
-      sql.add("ISNULL("+getSqlFrom(field)+",'')");
+      sql.add("COALESCE("+getSqlFrom(field)+",'')");
     }
     return StringUtils.join(sql, " + ");
   }

--- a/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
+++ b/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
@@ -1100,15 +1100,6 @@ class SqlServerDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#rebuildTriggers(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> rebuildTriggers(Table table) {
-    return SqlDialect.NO_STATEMENTS;
-  }
-
-
-  /**
    * SQL server places a shared lock on a record when it is selected without doing anything else (no MVCC)
    * so no need to specify a lock mode.
    *

--- a/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
+++ b/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
@@ -106,15 +106,6 @@ class SqlServerDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#truncateTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> truncateTableStatements(Table table) {
-    return Arrays.asList("TRUNCATE TABLE " + schemaNamePrefix() + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#tableDeploymentStatements(org.alfasoftware.morf.metadata.Table)
    */
   @Override

--- a/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
+++ b/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
@@ -427,15 +427,6 @@ class SqlServerDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForIsNull(org.alfasoftware.morf.sql.element.Function)
-   */
-  @Override
-  protected String getSqlForIsNull(Function function) {
-    return "ISNULL(" + getSqlFrom(function.getArguments().get(0)) + ", " + getSqlFrom(function.getArguments().get(1)) + ") ";
-  }
-
-
-  /**
    * {@inheritDoc}
    *
    * @see org.alfasoftware.morf.jdbc.SqlDialect#decorateTemporaryTableName(java.lang.String)

--- a/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
+++ b/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
@@ -115,15 +115,6 @@ class SqlServerDialect extends SqlDialect {
 
 
   /**
-   * @see org.alfasoftware.morf.jdbc.SqlDialect#deleteAllFromTableStatements(org.alfasoftware.morf.metadata.Table)
-   */
-  @Override
-  public Collection<String> deleteAllFromTableStatements(Table table) {
-    return Arrays.asList("DELETE FROM " + schemaNamePrefix() + table.getName());
-  }
-
-
-  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#tableDeploymentStatements(org.alfasoftware.morf.metadata.Table)
    */
   @Override

--- a/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
+++ b/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
@@ -321,7 +321,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedSelectWithConcatenation1() {
-    return "SELECT ISNULL(assetDescriptionLine1,'') + ISNULL(' ','') + ISNULL(assetDescriptionLine2,'') AS assetDescription FROM TESTSCHEMA.schedule";
+    return "SELECT COALESCE(assetDescriptionLine1,'') + COALESCE(' ','') + COALESCE(assetDescriptionLine2,'') AS assetDescription FROM TESTSCHEMA.schedule";
   }
 
 
@@ -330,7 +330,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedSelectWithConcatenation2() {
-    return "SELECT ISNULL(assetDescriptionLine1,'') + ISNULL('XYZ','') + ISNULL(assetDescriptionLine2,'') AS assetDescription FROM TESTSCHEMA.schedule";
+    return "SELECT COALESCE(assetDescriptionLine1,'') + COALESCE('XYZ','') + COALESCE(assetDescriptionLine2,'') AS assetDescription FROM TESTSCHEMA.schedule";
   }
 
 
@@ -339,7 +339,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedConcatenationWithCase() {
-    return "SELECT ISNULL(assetDescriptionLine1,'') + ISNULL(CASE WHEN (taxVariationIndicator = 'Y') THEN exposureCustomerNumber ELSE invoicingCustomerNumber END,'') AS test FROM TESTSCHEMA.schedule";
+    return "SELECT COALESCE(assetDescriptionLine1,'') + COALESCE(CASE WHEN (taxVariationIndicator = 'Y') THEN exposureCustomerNumber ELSE invoicingCustomerNumber END,'') AS test FROM TESTSCHEMA.schedule";
   }
 
 
@@ -348,7 +348,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedConcatenationWithFunction() {
-    return "SELECT ISNULL(assetDescriptionLine1,'') + ISNULL(MAX(scheduleStartDate),'') AS test FROM TESTSCHEMA.schedule";
+    return "SELECT COALESCE(assetDescriptionLine1,'') + COALESCE(MAX(scheduleStartDate),'') AS test FROM TESTSCHEMA.schedule";
   }
 
 
@@ -357,7 +357,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedConcatenationWithMultipleFieldLiterals() {
-    return "SELECT ISNULL('ABC','') + ISNULL(' ','') + ISNULL('DEF','') AS assetDescription FROM TESTSCHEMA.schedule";
+    return "SELECT COALESCE('ABC','') + COALESCE(' ','') + COALESCE('DEF','') AS assetDescription FROM TESTSCHEMA.schedule";
   }
 
 
@@ -366,7 +366,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedNestedConcatenations() {
-    return "SELECT ISNULL(field1,'') + ISNULL(ISNULL(field2,'') + ISNULL('XYZ',''),'') AS test FROM TESTSCHEMA.schedule";
+    return "SELECT COALESCE(field1,'') + COALESCE(COALESCE(field2,'') + COALESCE('XYZ',''),'') AS test FROM TESTSCHEMA.schedule";
   }
 
 

--- a/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
+++ b/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
@@ -375,7 +375,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedIsNull() {
-    return "ISNULL('A', 'B') ";
+    return "COALESCE('A', 'B') ";
   }
 
 

--- a/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
+++ b/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
@@ -375,7 +375,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedIsNull() {
-    return "COALESCE('A', 'B') ";
+    return "COALESCE('A', 'B')";
   }
 
 

--- a/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
+++ b/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
@@ -1138,6 +1138,15 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedRenameIndexStatements() {
+    return ImmutableList.of("sp_rename N'TESTSCHEMA.Test.Test_1', N'Test_2', N'INDEX'");
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRenameIndexStatements()
+   */
+  @Override
+  protected List<String> expectedRenameTempIndexStatements() {
     return ImmutableList.of("sp_rename N'TESTSCHEMA.#TempTest.TempTest_1', N'TempTest_2', N'INDEX'");
   }
 

--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
@@ -270,6 +270,8 @@ public abstract class AbstractSqlDialectTest {
    */
   protected SqlDialect testDialect;
 
+  private Table testTable;
+
   private Table testTempTable;
   private Table nonNullTempTable;
   private Table alternateTestTempTable;
@@ -289,7 +291,7 @@ public abstract class AbstractSqlDialectTest {
     testDialect = createTestDialect();
 
     // Main test table
-    Table testTable = table(TEST_TABLE)
+    testTable = table(TEST_TABLE)
         .columns(
           idColumn(),
           versionColumn(),
@@ -3913,7 +3915,17 @@ public abstract class AbstractSqlDialectTest {
   @SuppressWarnings("unchecked")
   @Test
   public void testRenameIndexStatements() {
-    compareStatements(expectedRenameIndexStatements(), testDialect.renameIndexStatements(testTempTable, "TempTest_1", "TempTest_2"));
+    compareStatements(expectedRenameIndexStatements(), testDialect.renameIndexStatements(testTable, "Test_1", "Test_2"));
+  }
+
+
+  /**
+   * Tests that the syntax is correct for renaming an index.
+   */
+  @SuppressWarnings("unchecked")
+  @Test
+  public void testRenameTempIndexStatements() {
+    compareStatements(expectedRenameTempIndexStatements(), testDialect.renameIndexStatements(testTempTable, "TempTest_1", "TempTest_2"));
   }
 
 
@@ -4283,6 +4295,12 @@ public abstract class AbstractSqlDialectTest {
    * @return Expected SQL for {@link #testRenameIndexStatements()}
    */
   protected abstract List<String> expectedRenameIndexStatements();
+
+
+  /**
+   * @return Expected SQL for {@link #testRenameTempIndexStatements()}
+   */
+  protected abstract List<String> expectedRenameTempIndexStatements();
 
 
   /**


### PR DESCRIPTION
I have cleaned-up SqlDialect and its descendants and unified them a bit.
- Extracted a few methods into the parent where possible.
- Made tiny inconsequential changes to the various dialects to unify behaviour.
- These are mostly in preparation for future channges and improvements.

Reviewing this commit by commit might make more sense than looking at the whole PR diff,
as this is a bigger collection of various refactors and clean-ups, rather than a concise change.