### PR TITLE
Oracle unicode parameter fix

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ResultSetComparer.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ResultSetComparer.java
@@ -263,8 +263,8 @@ public class ResultSetComparer {
    */
   public int compare(int[] keyColumns, SelectStatement left, SelectStatement right, Connection leftConnection, Connection rightConnection, CompareCallback callback,
                      StatementParameters leftStatementParameters, StatementParameters rightStatementParameters) {
-    try (NamedParameterPreparedStatement statementLeft = NamedParameterPreparedStatement.parse(leftSqlDialect.convertStatementToSQL(left)).createForQueryOn(leftConnection);
-         NamedParameterPreparedStatement statementRight = NamedParameterPreparedStatement.parse(rightSqlDialect.convertStatementToSQL(right)).createForQueryOn(rightConnection);
+    try (NamedParameterPreparedStatement statementLeft = NamedParameterPreparedStatement.parseSql(leftSqlDialect.convertStatementToSQL(left), leftSqlDialect).createForQueryOn(leftConnection);
+         NamedParameterPreparedStatement statementRight = NamedParameterPreparedStatement.parseSql(rightSqlDialect.convertStatementToSQL(right), rightSqlDialect).createForQueryOn(rightConnection);
          ResultSet rsLeft = parameteriseAndExecute(statementLeft, left, leftStatementParameters, leftSqlDialect);
          ResultSet rsRight = parameteriseAndExecute(statementRight, right, rightStatementParameters, rightSqlDialect)) {
       return compare(keyColumns, rsLeft, rsRight, callback);

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlScriptExecutor.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlScriptExecutor.java
@@ -15,8 +15,6 @@
 
 package org.alfasoftware.morf.jdbc;
 
-import static org.alfasoftware.morf.jdbc.NamedParameterPreparedStatement.parse;
-
 import java.sql.Connection;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -287,7 +285,7 @@ public class SqlScriptExecutor {
     int numberOfRowsUpdated = 0;
     try {
       try {
-        try (NamedParameterPreparedStatement preparedStatement = NamedParameterPreparedStatement.parse(sqlStatement).createFor(connection)) {
+        try (NamedParameterPreparedStatement preparedStatement = NamedParameterPreparedStatement.parseSql(sqlStatement, sqlDialect).createFor(connection)) {
           sqlDialect.prepareStatementParameters(preparedStatement, parameterMetadata, parameterData);
           numberOfRowsUpdated = preparedStatement.executeUpdate();
         }
@@ -521,7 +519,7 @@ public class SqlScriptExecutor {
       Connection connection, ResultSetProcessor<T> resultSetProcessor, Optional<Integer> maxRows, Optional<Integer> queryTimeout,
       boolean standalone) {
     try {
-      ParseResult parseResult = parse(sql);
+      ParseResult parseResult = NamedParameterPreparedStatement.parseSql(sql, sqlDialect);
       try (NamedParameterPreparedStatement preparedStatement = standalone ? parseResult.createForQueryOn(connection) : parseResult.createFor(connection)) {
         if (standalone) {
           preparedStatement.setFetchSize(sqlDialect.fetchSizeForBulkSelects());
@@ -599,7 +597,7 @@ public class SqlScriptExecutor {
    */
   public void executeStatementBatch(String sqlStatement, Iterable<SqlParameter> parameterMetadata, Iterable<? extends DataValueLookup> parameterData, Connection connection, boolean explicitCommit, int statementsPerFlush) {
     try {
-      try (NamedParameterPreparedStatement preparedStatement = NamedParameterPreparedStatement.parse(sqlStatement).createFor(connection)) {
+      try (NamedParameterPreparedStatement preparedStatement = NamedParameterPreparedStatement.parseSql(sqlStatement, sqlDialect).createFor(connection)) {
         executeStatementBatch(preparedStatement, parameterMetadata, parameterData, connection, explicitCommit, statementsPerFlush);
       } finally {
         if (explicitCommit) {

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/TestNamedParameterPreparedStatement.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/TestNamedParameterPreparedStatement.java
@@ -27,9 +27,8 @@ import java.sql.Connection;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 
-import org.junit.Test;
-
 import org.alfasoftware.morf.jdbc.NamedParameterPreparedStatement.ParseResult;
+import org.junit.Test;
 
 /**
  * Tests {@link NamedParameterPreparedStatement}.
@@ -45,8 +44,9 @@ public class TestNamedParameterPreparedStatement {
    */
   @Test
   public void testParse() {
-    ParseResult parseResult = NamedParameterPreparedStatement.parse(
-      "SELECT :fee,:fi, :fo(:fum), ':eek' FROM :fum WHERE :fum AND :fo"
+    ParseResult parseResult = NamedParameterPreparedStatement.parseSql(
+      "SELECT :fee,:fi, :fo(:fum), ':eek' FROM :fum WHERE :fum AND :fo",
+      mock(SqlDialect.class)
     );
 
     assertThat("Parsed SQL", parseResult.getParsedSql(),                equalTo("SELECT ?,?, ?(?), ':eek' FROM ? WHERE ? AND ?"));
@@ -67,7 +67,7 @@ public class TestNamedParameterPreparedStatement {
     Connection connection = mock(Connection.class);
     PreparedStatement underlying = mock(PreparedStatement.class);
     when(connection.prepareStatement("SELECT * FROM somewhere")).thenReturn(underlying);
-    NamedParameterPreparedStatement.parse("SELECT * FROM somewhere").createFor(connection).setMaxRows(123);
+    NamedParameterPreparedStatement.parseSql("SELECT * FROM somewhere", mock(SqlDialect.class)).createFor(connection).setMaxRows(123);
     verify(underlying).setMaxRows(123);
   }
 }

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
@@ -2413,7 +2413,7 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
             parameter("parameterValue").type(DataType.STRING).as("column4")
           )
         );
-    NamedParameterPreparedStatement preparedStatement = NamedParameterPreparedStatement.parse(sqlDialect.convertStatementToSQL(merge)).createFor(connection);
+    NamedParameterPreparedStatement preparedStatement = NamedParameterPreparedStatement.parseSql(sqlDialect.convertStatementToSQL(merge), sqlDialect).createFor(connection);
     try {
 
       // Put in two records.  The first should merge with the initial data set.
@@ -2466,7 +2466,7 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
     UpdateStatement update = update(tableRef("MergeTableMultipleKeys"))
         .set(column2, column3, column4)
         .where(field("column1").eq(column1));
-    ParseResult parsed = NamedParameterPreparedStatement.parse(sqlDialect.convertStatementToSQL(update));
+    ParseResult parsed = NamedParameterPreparedStatement.parseSql(sqlDialect.convertStatementToSQL(update), sqlDialect);
 
     NamedParameterPreparedStatement preparedStatement = parsed.createFor(connection);
     try {
@@ -2520,7 +2520,7 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
         ))
         .orderBy(field("field1"), field("field2"));
 
-    NamedParameterPreparedStatement preparedStatement = NamedParameterPreparedStatement.parse(sqlDialect.convertStatementToSQL(select)).createForQueryOn(connection);
+    NamedParameterPreparedStatement preparedStatement = NamedParameterPreparedStatement.parseSql(sqlDialect.convertStatementToSQL(select), sqlDialect).createForQueryOn(connection);
     try {
       preparedStatement.setFetchSize(sqlDialect.fetchSizeForBulkSelects());
       sqlDialect.prepareStatementParameters(


### PR DESCRIPTION
NamedParameterPreparedStatement.setString(SqlParameter, String) should use unicode
java.sql.PreparedStatement.setNString(int, String) for Oracle, instead of non-unicode
java.sql.PreparedStatement.setString(int, String).