### PR TITLE
Fix the signature of AliasedField.in(List<Object>) to AliasedField.in(Iterable<? extends Object>)

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/AliasedField.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/AliasedField.java
@@ -18,8 +18,6 @@ package org.alfasoftware.morf.sql.element;
 import static org.alfasoftware.morf.sql.SqlUtils.bracket;
 import static org.alfasoftware.morf.util.DeepCopyTransformations.noTransformation;
 
-import java.util.List;
-
 import org.alfasoftware.morf.sql.SelectStatement;
 import org.alfasoftware.morf.sql.SqlUtils;
 import org.alfasoftware.morf.util.DeepCopyTransformation;
@@ -333,7 +331,7 @@ public abstract class AliasedField implements AliasedFieldBuilder, DeepCopyableW
    * @param values The values for comparison
    * @return The resulting {@link Criterion}.
    */
-  public Criterion in(List<Object> values) {
+  public Criterion in(Iterable<? extends Object> values) {
     return Criterion.in(this, values);
   }
 

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
@@ -1350,6 +1350,7 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
    */
   @Test
   public void ItestBooleanFields() throws SQLException {
+    ImmutableList<Boolean> listOfTrueAndFalse = ImmutableList.of(true, false); // deliberately not a List<Object>
 
     SqlScriptExecutor executor = sqlScriptExecutorProvider.get(new LoggingSqlScriptVisitor());
 
@@ -1366,7 +1367,8 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
                                        field("column1").eq(literal(true)),
                                        field("column1").eq(literal(false)),
                                        field("column1").in(true, false),
-                                       field("column1").in(literal(true), literal(false))
+                                       field("column1").in(literal(true), literal(false),
+                                       field("column1").in(listOfTrueAndFalse))
                                      ));
     UpdateStatement updateStatement = update(tableRef("BooleanTable"))
                                      .set(literal(true).as("column1"), literal(false).as("column2"));


### PR DESCRIPTION
Note: It previously would not compile against ImmutableList<Integer> correctly.