### PR TITLE
Remove dependency on com.google.inject.extensions:guice-multibindings

### DIFF
--- a/morf-core/pom.xml
+++ b/morf-core/pom.xml
@@ -65,10 +65,6 @@
       <artifactId>guice-assistedinject</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.google.inject.extensions</groupId>
-      <artifactId>guice-multibindings</artifactId>
-    </dependency>
-    <dependency>
       <groupId>joda-time</groupId>
       <artifactId>joda-time</artifactId>
     </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -312,11 +312,6 @@
         <version>${guice.version}</version>
       </dependency>
       <dependency>
-        <groupId>com.google.inject.extensions</groupId>
-        <artifactId>guice-multibindings</artifactId>
-        <version>${guice.version}</version>
-      </dependency>
-      <dependency>
         <groupId>com.h2database</groupId>
         <artifactId>h2</artifactId>
         <version>${h2.version}</version>


### PR DESCRIPTION
This drops the dependency on guice-multibindings - it's been empty since Guice 4.2 when multibindings support moved into the "core" Guice project - see https://github.com/google/guice/wiki/Guice42#changes-since-guice-42