### PR TITLE
Bump maven-surefire-plugin version to 2.22.2.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -41,7 +41,7 @@
     <maven-javadoc-plugin.version>2.9.1</maven-javadoc-plugin.version>
     <maven-release-plugin.version>2.5.3</maven-release-plugin.version>
     <maven-source-plugin.version>3.0.1</maven-source-plugin.version>
-    <maven-surefire-plugin.version>2.13</maven-surefire-plugin.version>
+    <maven-surefire-plugin.version>2.22.2</maven-surefire-plugin.version>
     <findbugs-maven-plugin.version>3.0.4</findbugs-maven-plugin.version>
     <maven-checkstyle-plugin.version>2.17</maven-checkstyle-plugin.version>
     <checkstyle.version>8.12</checkstyle.version>


### PR DESCRIPTION
Fix for Intermittent test failure TestDatabaseDataSetConsumer.testBlobInsertion.

TestCaseInsensitiveString is annotated with @net.jcip.annotations.NotThreadSafe
and maven-surefire-plugin:2.18 recognizes this annotation.

Unfortunnatelly, we are runnning maven-surefire-plugin:2.13.