### PR TITLE
Add support for blob length for different dialects

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -2222,7 +2222,7 @@ public abstract class SqlDialect {
    * @see org.alfasoftware.morf.sql.element.Function#blobLength(AliasedField)
    */
   protected String getSqlforBlobLength(Function function) {
-    return String.format("OCTET_LENGTH(%s)", getSqlFrom(function.getArguments().get(0)));
+    return String.format("LENGTH(%s)", getSqlFrom(function.getArguments().get(0)));
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -1761,47 +1761,47 @@ public abstract class SqlDialect {
         throw new IllegalArgumentException("The COUNT function should have only have one or zero arguments. This function has " + function.getArguments().size());
 
       case COUNT_DISTINCT:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForCountDistinct(function);
 
       case AVERAGE:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForAverage(function);
 
       case AVERAGE_DISTINCT:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForAverageDistinct(function);
 
       case LENGTH:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlforLength(function);
 
       case BLOB_LENGTH:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlforBlobLength(function);
 
       case SOME:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForSome(function);
 
       case EVERY:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForEvery(function);
 
       case MAX:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForMax(function);
 
       case MIN:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForMin(function);
 
       case SUM:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForSum(function);
 
       case SUM_DISTINCT:
-        checkFunctionHasSingleArgument(function);
+        checkSingleArgument(function);
         return getSqlForSumDistinct(function);
 
       case IS_NULL:
@@ -1965,7 +1965,7 @@ public abstract class SqlDialect {
     }
   }
 
-  private void checkFunctionHasSingleArgument(Function function) {
+  private void checkSingleArgument(Function function) {
     if (function.getArguments().size() != 1) {
       throw new IllegalArgumentException("The " + function.getType() + " function should have only one argument. This function has " + function.getArguments().size());
     }

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -41,7 +41,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 
 import org.alfasoftware.morf.dataset.Record;
@@ -2216,7 +2215,8 @@ public abstract class SqlDialect {
 
   /**
    * Converts the function get LENGTH of Blob data or field into SQL.
-   *
+   * Use LENGTH instead of OCTET_LENGTH as they are synonymous in MySQl and PostGreSQL. In H2 LENGTH returns the correct
+   * number of bytes, whereas OCTET_LENGTH returns 2 times the byte length.
    * @param function the function to convert.
    * @return a string representation of the SQL.
    * @see org.alfasoftware.morf.sql.element.Function#blobLength(AliasedField)

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/SqlUtils.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/SqlUtils.java
@@ -24,6 +24,7 @@ import org.alfasoftware.morf.metadata.Column;
 import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.sql.element.AliasedField;
 import org.alfasoftware.morf.sql.element.AliasedFieldBuilder;
+import org.alfasoftware.morf.sql.element.BlobFieldLiteral;
 import org.alfasoftware.morf.sql.element.BracketedExpression;
 import org.alfasoftware.morf.sql.element.CaseStatement;
 import org.alfasoftware.morf.sql.element.Cast;
@@ -340,6 +341,28 @@ public class SqlUtils {
    */
   public static FieldLiteral literal(Character value) {
     return new FieldLiteral(value);
+  }
+
+
+  /**
+   * Constructs a new {@link BlobFieldLiteral} with a byte array source.
+   *
+   * @param value the literal value to use
+   * @return {@link BlobFieldLiteral}
+   */
+  public static BlobFieldLiteral blobliteral(byte[] value) {
+    return new BlobFieldLiteral(value);
+  }
+
+
+  /**
+   * Constructs a new {@link BlobFieldLiteral} with a String source.
+   *
+   * @param value the literal value to use
+   * @return {@link BlobFieldLiteral}
+   */
+  public static BlobFieldLiteral blobliteral(String value) {
+    return new BlobFieldLiteral(value);
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/SqlUtils.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/SqlUtils.java
@@ -350,7 +350,7 @@ public class SqlUtils {
    * @param value the literal value to use
    * @return {@link BlobFieldLiteral}
    */
-  public static BlobFieldLiteral blobliteral(byte[] value) {
+  public static BlobFieldLiteral blob(byte[] value) {
     return new BlobFieldLiteral(value);
   }
 
@@ -361,7 +361,7 @@ public class SqlUtils {
    * @param value the literal value to use
    * @return {@link BlobFieldLiteral}
    */
-  public static BlobFieldLiteral blobliteral(String value) {
+  public static BlobFieldLiteral blob(String value) {
     return new BlobFieldLiteral(value);
   }
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BlobFieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BlobFieldLiteral.java
@@ -2,17 +2,18 @@ package org.alfasoftware.morf.sql.element;
 
 import org.alfasoftware.morf.metadata.DataType;
 
+import java.math.BigInteger;
 import java.nio.charset.StandardCharsets;
-import java.util.Base64;
 
 /**
- * Since we store binary data, we will store the values in base64 format and do the appropriate conversion based on dialect to the actual value when saving in DB.
- * So {@link FieldLiteral#getValue()} will always return the base64 encoded string.
+ * Since we store binary data, we will store the values in hex format, since all DBs support inserting
+ * blob data using hex values.
+ * So {@link FieldLiteral#getValue()} will always return the hex encoded string.
  */
 public class BlobFieldLiteral extends FieldLiteral {
 
     public BlobFieldLiteral(byte[] bytes) {
-        super("", Base64.getEncoder().encodeToString(bytes), DataType.BLOB);
+        super("", new BigInteger(bytes).toString(16).toUpperCase(), DataType.BLOB);
     }
 
     public BlobFieldLiteral(String text) {

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BlobFieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BlobFieldLiteral.java
@@ -13,7 +13,7 @@ import java.nio.charset.StandardCharsets;
 public class BlobFieldLiteral extends FieldLiteral {
 
     public BlobFieldLiteral(byte[] bytes) {
-        super("", new BigInteger(bytes).toString(16).toUpperCase(), DataType.BLOB);
+        super(new BigInteger(bytes).toString(16).toUpperCase(), DataType.BLOB);
     }
 
     public BlobFieldLiteral(String text) {

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BlobFieldLiteral.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/BlobFieldLiteral.java
@@ -1,0 +1,21 @@
+package org.alfasoftware.morf.sql.element;
+
+import org.alfasoftware.morf.metadata.DataType;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+
+/**
+ * Since we store binary data, we will store the values in base64 format and do the appropriate conversion based on dialect to the actual value when saving in DB.
+ * So {@link FieldLiteral#getValue()} will always return the base64 encoded string.
+ */
+public class BlobFieldLiteral extends FieldLiteral {
+
+    public BlobFieldLiteral(byte[] bytes) {
+        super("", Base64.getEncoder().encodeToString(bytes), DataType.BLOB);
+    }
+
+    public BlobFieldLiteral(String text) {
+        this(text.getBytes(StandardCharsets.UTF_8));
+    }
+}

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
@@ -22,7 +22,7 @@ import static org.alfasoftware.morf.metadata.SchemaUtils.column;
 import static org.alfasoftware.morf.metadata.SchemaUtils.index;
 import static org.alfasoftware.morf.metadata.SchemaUtils.schema;
 import static org.alfasoftware.morf.metadata.SchemaUtils.table;
-import static org.alfasoftware.morf.sql.SqlUtils.blobliteral;
+import static org.alfasoftware.morf.sql.SqlUtils.blob;
 import static org.alfasoftware.morf.sql.SqlUtils.caseStatement;
 import static org.alfasoftware.morf.sql.SqlUtils.cast;
 import static org.alfasoftware.morf.sql.SqlUtils.concat;
@@ -102,12 +102,7 @@ import org.alfasoftware.morf.metadata.DataSetUtils.RecordBuilder;
 import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.metadata.Schema;
 import org.alfasoftware.morf.metadata.Table;
-import org.alfasoftware.morf.sql.InsertStatement;
-import org.alfasoftware.morf.sql.MergeStatement;
-import org.alfasoftware.morf.sql.SelectFirstStatement;
-import org.alfasoftware.morf.sql.SelectStatement;
-import org.alfasoftware.morf.sql.TruncateStatement;
-import org.alfasoftware.morf.sql.UpdateStatement;
+import org.alfasoftware.morf.sql.*;
 import org.alfasoftware.morf.sql.element.AliasedField;
 import org.alfasoftware.morf.sql.element.CaseStatement;
 import org.alfasoftware.morf.sql.element.Cast;
@@ -1598,20 +1593,20 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
         InsertStatement insertStatement = insert()
                 .into(tableRef("BlobTable"))
                 .fields(field("column1"), field("column2"))
-                .values(blobliteral(BLOB1_VALUE).as("column1"), blobliteral(BLOB2_VALUE.getBytes()).as("column2"));
+                .values(blob(BLOB1_VALUE).as("column1"), SqlUtils.blob(BLOB2_VALUE.getBytes()).as("column2"));
         SelectStatement selectStatementAfterInsert = select(field("column1"), field("column2"))
                 .from(tableRef("BlobTable"))
                 .where(or(
-                        field("column1").eq(blobliteral(BLOB1_VALUE.getBytes())),
-                        field("column1").eq(blobliteral(BLOB1_VALUE))
+                        field("column1").eq(SqlUtils.blob(BLOB1_VALUE.getBytes())),
+                        field("column1").eq(blob(BLOB1_VALUE))
                 ));
         UpdateStatement updateStatement = update(tableRef("BlobTable"))
-                .set(blobliteral(BLOB1_VALUE + " Updated").as("column1"), blobliteral((BLOB2_VALUE + " Updated").getBytes()).as("column2"));
+                .set(blob(BLOB1_VALUE + " Updated").as("column1"), SqlUtils.blob((BLOB2_VALUE + " Updated").getBytes()).as("column2"));
         SelectStatement selectStatementAfterUpdate = select(field("column1"), field("column2"))
                 .from(tableRef("BlobTable"))
                 .where(or(
-                        field("column1").eq(blobliteral((BLOB1_VALUE + " Updated").getBytes())),
-                        field("column1").eq(blobliteral(BLOB1_VALUE + " Updated"))
+                        field("column1").eq(SqlUtils.blob((BLOB1_VALUE + " Updated").getBytes())),
+                        field("column1").eq(blob(BLOB1_VALUE + " Updated"))
                 ));
 
         // Insert

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
@@ -47,40 +47,7 @@ import static org.alfasoftware.morf.sql.element.Criterion.in;
 import static org.alfasoftware.morf.sql.element.Criterion.like;
 import static org.alfasoftware.morf.sql.element.Criterion.not;
 import static org.alfasoftware.morf.sql.element.Criterion.or;
-import static org.alfasoftware.morf.sql.element.Function.addDays;
-import static org.alfasoftware.morf.sql.element.Function.average;
-import static org.alfasoftware.morf.sql.element.Function.averageDistinct;
-import static org.alfasoftware.morf.sql.element.Function.coalesce;
-import static org.alfasoftware.morf.sql.element.Function.count;
-import static org.alfasoftware.morf.sql.element.Function.countDistinct;
-import static org.alfasoftware.morf.sql.element.Function.dateToYyyyMMddHHmmss;
-import static org.alfasoftware.morf.sql.element.Function.dateToYyyymmdd;
-import static org.alfasoftware.morf.sql.element.Function.daysBetween;
-import static org.alfasoftware.morf.sql.element.Function.every;
-import static org.alfasoftware.morf.sql.element.Function.floor;
-import static org.alfasoftware.morf.sql.element.Function.greatest;
-import static org.alfasoftware.morf.sql.element.Function.isnull;
-import static org.alfasoftware.morf.sql.element.Function.lastDayOfMonth;
-import static org.alfasoftware.morf.sql.element.Function.least;
-import static org.alfasoftware.morf.sql.element.Function.leftPad;
-import static org.alfasoftware.morf.sql.element.Function.leftTrim;
-import static org.alfasoftware.morf.sql.element.Function.length;
-import static org.alfasoftware.morf.sql.element.Function.lowerCase;
-import static org.alfasoftware.morf.sql.element.Function.max;
-import static org.alfasoftware.morf.sql.element.Function.mod;
-import static org.alfasoftware.morf.sql.element.Function.monthsBetween;
-import static org.alfasoftware.morf.sql.element.Function.now;
-import static org.alfasoftware.morf.sql.element.Function.power;
-import static org.alfasoftware.morf.sql.element.Function.random;
-import static org.alfasoftware.morf.sql.element.Function.randomString;
-import static org.alfasoftware.morf.sql.element.Function.rightTrim;
-import static org.alfasoftware.morf.sql.element.Function.some;
-import static org.alfasoftware.morf.sql.element.Function.substring;
-import static org.alfasoftware.morf.sql.element.Function.sum;
-import static org.alfasoftware.morf.sql.element.Function.sumDistinct;
-import static org.alfasoftware.morf.sql.element.Function.trim;
-import static org.alfasoftware.morf.sql.element.Function.upperCase;
-import static org.alfasoftware.morf.sql.element.Function.yyyymmddToDate;
+import static org.alfasoftware.morf.sql.element.Function.*;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.instanceOf;
@@ -2231,7 +2198,7 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
     final byte[] value = "hello world BLOB".getBytes();
 
     SqlScriptExecutor executor = sqlScriptExecutorProvider.get(new LoggingSqlScriptVisitor());
-    String sql = convertStatementToSQL(select(field("blobCol"), length(field("blobCol")).as("lengthResult"))
+    String sql = convertStatementToSQL(select(field("blobCol"), blobLength(field("blobCol")).as("lengthResult"))
                                                                         .from(tableRef("SimpleTypes"))
                                                                         .orderBy(field("lengthResult")));
 

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestSqlStatements.java
@@ -22,6 +22,7 @@ import static org.alfasoftware.morf.metadata.SchemaUtils.column;
 import static org.alfasoftware.morf.metadata.SchemaUtils.index;
 import static org.alfasoftware.morf.metadata.SchemaUtils.schema;
 import static org.alfasoftware.morf.metadata.SchemaUtils.table;
+import static org.alfasoftware.morf.sql.SqlUtils.blobliteral;
 import static org.alfasoftware.morf.sql.SqlUtils.caseStatement;
 import static org.alfasoftware.morf.sql.SqlUtils.cast;
 import static org.alfasoftware.morf.sql.SqlUtils.concat;
@@ -168,6 +169,9 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
 
   private static final Log log = LogFactory.getLog(TestSqlStatements.class);
 
+  private static final String BLOB1_VALUE = "A Blob named One";
+  private static final String BLOB2_VALUE = "A Blob named Two";
+
   @Rule public InjectMembersRule injectMembersRule = new InjectMembersRule(new TestingDataSourceModule());
 
   @Inject
@@ -221,6 +225,11 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
       .columns(
         column("column1", DataType.BOOLEAN).nullable(),
         column("column2", DataType.BOOLEAN).nullable()
+      ),
+    table("BlobTable")
+      .columns(
+        column("column1", DataType.BLOB).nullable(),
+        column("column2", DataType.BLOB).nullable()
       ),
     table("AccumulateBooleanTable")
       .columns(
@@ -418,6 +427,11 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
       record()
         .setBoolean("column1", false)
         .setBoolean("column2", true)
+    )
+    .table("BlobTable",
+      record()
+        .setByteArray("column1", BLOB1_VALUE.getBytes())
+        .setByteArray("column2", BLOB2_VALUE.getBytes())
     )
     .table("AccumulateBooleanTable",
       record()
@@ -1569,7 +1583,80 @@ public class TestSqlStatements { //CHECKSTYLE:OFF
   }
 
 
-  /**
+    /**
+     * Test the behaviour of SELECTs, INSERTs and UPDATEs of blob fields.  In the process
+     * we test a lot of {@link SqlScriptExecutor}'s statement handling capabilities
+     *
+     * @throws SQLException if something goes wrong.
+     */
+    @Test
+    public void testBlobFields() throws SQLException {
+
+        SqlScriptExecutor executor = sqlScriptExecutorProvider.get(new LoggingSqlScriptVisitor());
+
+        // Set up queries
+        InsertStatement insertStatement = insert()
+                .into(tableRef("BlobTable"))
+                .fields(field("column1"), field("column2"))
+                .values(blobliteral(BLOB1_VALUE).as("column1"), blobliteral(BLOB2_VALUE.getBytes()).as("column2"));
+        SelectStatement selectStatementAfterInsert = select(field("column1"), field("column2"))
+                .from(tableRef("BlobTable"))
+                .where(or(
+                        field("column1").eq(blobliteral(BLOB1_VALUE.getBytes())),
+                        field("column1").eq(blobliteral(BLOB1_VALUE))
+                ));
+        UpdateStatement updateStatement = update(tableRef("BlobTable"))
+                .set(blobliteral(BLOB1_VALUE + " Updated").as("column1"), blobliteral((BLOB2_VALUE + " Updated").getBytes()).as("column2"));
+        SelectStatement selectStatementAfterUpdate = select(field("column1"), field("column2"))
+                .from(tableRef("BlobTable"))
+                .where(or(
+                        field("column1").eq(blobliteral((BLOB1_VALUE + " Updated").getBytes())),
+                        field("column1").eq(blobliteral(BLOB1_VALUE + " Updated"))
+                ));
+
+        // Insert
+        executor.execute(convertStatementToSQL(insertStatement, schema, null), connection);
+
+        // Check result - note that this is deliberately not tidy - we are making sure that results get
+        // passed back up to this scope correctly.
+        String sql = convertStatementToSQL(selectStatementAfterInsert);
+        Integer numberOfRecords = executor.executeQuery(sql, connection, new ResultSetProcessor<Integer>() {
+            @Override
+            public Integer process(ResultSet resultSet) throws SQLException {
+                int result = 0;
+                while (resultSet.next()) {
+                    result++;
+                    assertEquals("column1 blob value not correctly set/returned after insert", BLOB1_VALUE, new String(resultSet.getBytes(1)));
+                    assertEquals("column2 blob value not correctly set/returned after insert", BLOB2_VALUE, new String(resultSet.getBytes(2)));
+                }
+                return result;
+            }
+        });
+        assertEquals("Should be exactly two records", 2, numberOfRecords.intValue());
+
+        // Update
+        executor.execute(ImmutableList.of(convertStatementToSQL(updateStatement)), connection);
+
+        // Check result- note that this is deliberately not tidy - we are making sure that results get
+        // passed back up to this scope correctly.
+        sql = convertStatementToSQL(selectStatementAfterUpdate);
+        numberOfRecords = executor.executeQuery(sql, connection, new ResultSetProcessor<Integer>() {
+            @Override
+            public Integer process(ResultSet resultSet) throws SQLException {
+                int result = 0;
+                while (resultSet.next()) {
+                    result++;
+                    assertEquals("column1 blob value not correctly set/returned after update", BLOB1_VALUE + " Updated", new String(resultSet.getBytes(1)));
+                    assertEquals("column2 blob value not correctly set/returned after update", BLOB2_VALUE + " Updated", new String(resultSet.getBytes(2)));
+                }
+                return result;
+            }
+        });
+        assertEquals("Should be exactly two records", 2, numberOfRecords.intValue());
+    }
+
+
+    /**
    * Asserts that the number of records in the table are as expected.
    *
    * @param numberOfRecords The number of records expected.

--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
@@ -50,6 +50,7 @@ import org.alfasoftware.morf.sql.MergeStatement;
 import org.alfasoftware.morf.sql.SelectStatement;
 import org.alfasoftware.morf.sql.UseImplicitJoinOrder;
 import org.alfasoftware.morf.sql.element.AliasedField;
+import org.alfasoftware.morf.sql.element.BlobFieldLiteral;
 import org.alfasoftware.morf.sql.element.Cast;
 import org.alfasoftware.morf.sql.element.ConcatenatedField;
 import org.alfasoftware.morf.sql.element.FieldReference;
@@ -602,7 +603,12 @@ class MySqlDialect extends SqlDialect {
   }
 
 
-  /**
+    @Override
+    protected String getSqlFrom(BlobFieldLiteral field) {
+        return String.format("FROM_BASE64('%s')", field.getValue());
+    }
+
+    /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForYYYYMMDDToDate(org.alfasoftware.morf.sql.element.Function)
    */
   @Override

--- a/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
+++ b/morf-mysql/src/main/java/org/alfasoftware/morf/jdbc/mysql/MySqlDialect.java
@@ -605,7 +605,7 @@ class MySqlDialect extends SqlDialect {
 
     @Override
     protected String getSqlFrom(BlobFieldLiteral field) {
-        return String.format("FROM_BASE64('%s')", field.getValue());
+        return String.format("x'%s'", field.getValue());
     }
 
     /**

--- a/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
+++ b/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
@@ -1223,4 +1223,11 @@ public class TestMySqlDialect extends AbstractSqlDialectTest {
   protected String expectedDeleteWithLimitWithoutWhere() {
     return "DELETE FROM " + tableName(TEST_TABLE) + " LIMIT 1000";
   }
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedBlobLiteral(String)  ()
+   */
+  protected String expectedBlobLiteral(String value) {
+    return String.format("FROM_BASE64(%s)", super.expectedBlobLiteral(value));
+  }
 }

--- a/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
+++ b/morf-mysql/src/test/java/org/alfasoftware/morf/jdbc/mysql/TestMySqlDialect.java
@@ -1228,6 +1228,6 @@ public class TestMySqlDialect extends AbstractSqlDialectTest {
    * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedBlobLiteral(String)  ()
    */
   protected String expectedBlobLiteral(String value) {
-    return String.format("FROM_BASE64(%s)", super.expectedBlobLiteral(value));
+    return String.format("x%s", super.expectedBlobLiteral(value));
   }
 }

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -1205,9 +1205,13 @@ class OracleDialect extends SqlDialect {
     return result.toString().trim();
   }
 
+  /**
+   * @param field the BLOB field literal
+   * @return
+   */
   @Override
   protected String getSqlFrom(BlobFieldLiteral field) {
-    return String.format("UTL_ENCODE.BASE64_DECODE('%s')", field.getValue());
+    return String.format("HEXTORAW('%s')", field.getValue());
   }
 
   /**

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -51,6 +51,7 @@ import org.alfasoftware.morf.sql.UseImplicitJoinOrder;
 import org.alfasoftware.morf.sql.UseIndex;
 import org.alfasoftware.morf.sql.UseParallelDml;
 import org.alfasoftware.morf.sql.element.AliasedField;
+import org.alfasoftware.morf.sql.element.BlobFieldLiteral;
 import org.alfasoftware.morf.sql.element.ConcatenatedField;
 import org.alfasoftware.morf.sql.element.FieldReference;
 import org.alfasoftware.morf.sql.element.Function;
@@ -1170,6 +1171,11 @@ class OracleDialect extends SqlDialect {
   }
 
 
+  @Override
+  protected String getSqlforBlobLength(Function function) {
+    return String.format("dbms_lob.getlength(%s)", getSqlFrom(function.getArguments().get(0)));
+  }
+
   /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getFromDummyTable()
    */
@@ -1199,6 +1205,10 @@ class OracleDialect extends SqlDialect {
     return result.toString().trim();
   }
 
+  @Override
+  protected String getSqlFrom(BlobFieldLiteral field) {
+    return String.format("UTL_ENCODE.BASE64_DECODE('%s')", field.getValue());
+  }
 
   /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#selectStatementPreFieldDirectives(org.alfasoftware.morf.sql.SelectStatement)

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -1096,7 +1096,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedBlobLiteral(String value) {
-    return String.format("UTL_ENCODE.BASE64_DECODE(%s)",super.expectedBlobLiteral(value));
+    return String.format("HEXTORAW(%s)",super.expectedBlobLiteral(value));
   }
 
   /**

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -1092,6 +1092,14 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
 
 
   /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedBlobLiteral(String) ()
+   */
+  @Override
+  protected String expectedBlobLiteral(String value) {
+    return String.format("UTL_ENCODE.BASE64_DECODE(%s)",super.expectedBlobLiteral(value));
+  }
+
+  /**
    * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedDateToYyyymmddHHmmss()
    */
   @Override

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -28,6 +28,7 @@ import org.alfasoftware.morf.sql.MergeStatement;
 import org.alfasoftware.morf.sql.SelectFirstStatement;
 import org.alfasoftware.morf.sql.SelectStatementBuilder;
 import org.alfasoftware.morf.sql.element.AliasedField;
+import org.alfasoftware.morf.sql.element.BlobFieldLiteral;
 import org.alfasoftware.morf.sql.element.Cast;
 import org.alfasoftware.morf.sql.element.ConcatenatedField;
 import org.alfasoftware.morf.sql.element.Function;
@@ -306,6 +307,10 @@ class PostgreSQLDialect extends SqlDialect {
     return "CONCAT(" + StringUtils.join(sql, ", ") + ")";
   }
 
+  @Override
+  protected String getSqlFrom(BlobFieldLiteral field) {
+    return String.format("DECODE('%s', 'base64')", field.getValue());
+  }
 
   @Override
   protected String getSqlForDaysBetween(AliasedField toDate, AliasedField fromDate) {

--- a/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
+++ b/morf-postgresql/src/main/java/org/alfasoftware/morf/jdbc/postgresql/PostgreSQLDialect.java
@@ -309,7 +309,7 @@ class PostgreSQLDialect extends SqlDialect {
 
   @Override
   protected String getSqlFrom(BlobFieldLiteral field) {
-    return String.format("DECODE('%s', 'base64')", field.getValue());
+    return String.format("E'\\x%s'", field.getValue());
   }
 
   @Override

--- a/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
+++ b/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
@@ -522,7 +522,7 @@ public class TestPostgreSQLDialect extends AbstractSqlDialectTest {
    * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedBlobLiteral(String)  ()
    */
   protected String expectedBlobLiteral(String value) {
-    return String.format("DECODE(%s, 'base64')", super.expectedBlobLiteral(value));
+    return String.format("E'\\x%s'", value);
   }
 
 

--- a/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
+++ b/morf-postgresql/src/test/java/org/alfasoftware/morf/jdbc/postgresql/TestPostgreSQLDialect.java
@@ -4,8 +4,10 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.verify;
 
 import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
 import java.sql.SQLException;
 import java.util.Arrays;
+import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
@@ -504,6 +506,23 @@ public class TestPostgreSQLDialect extends AbstractSqlDialectTest {
   @Override
   protected String expectedLeftPad() {
     return "SELECT LPAD(stringField, 10, 'j') FROM testschema.Test";
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedBooleanLiteral(boolean) ()
+   */
+  @Override
+  protected String expectedBooleanLiteral(boolean value) {
+    return value ? "TRUE" : "FALSE";
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedBlobLiteral(String)  ()
+   */
+  protected String expectedBlobLiteral(String value) {
+    return String.format("DECODE(%s, 'base64')", super.expectedBlobLiteral(value));
   }
 
 
@@ -1165,18 +1184,6 @@ public class TestPostgreSQLDialect extends AbstractSqlDialectTest {
   @Override
   protected String expectedUpdateUsingSourceTableInDifferentSchema() {
     return "UPDATE " + tableName("FloatingRateRate") + " A SET settlementFrequency = (SELECT settlementFrequency FROM MYSCHEMA.FloatingRateDetail B WHERE (A.floatingRateDetailId = B.id))";
-  }
-
-  /**
-   * @return Expected SQL for {@link #testUpdateWithLiteralValues()}
-   */
-  @Override
-  protected String expectedUpdateWithLiteralValues() {
-    return String.format(
-        "UPDATE testschema.Test SET stringField = 'Value' WHERE ((field1 = TRUE) AND (field2 = FALSE) AND (field3 = TRUE) AND (field4 = FALSE) AND (field5 = %s) AND (field6 = %s) AND (field7 = 'Value') AND (field8 = 'Value'))",
-        expectedDateLiteral(),
-        expectedDateLiteral()
-      );
   }
 
   /**

--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
@@ -26,7 +26,7 @@ import static org.alfasoftware.morf.metadata.SchemaUtils.schema;
 import static org.alfasoftware.morf.metadata.SchemaUtils.table;
 import static org.alfasoftware.morf.metadata.SchemaUtils.versionColumn;
 import static org.alfasoftware.morf.metadata.SchemaUtils.view;
-import static org.alfasoftware.morf.sql.SqlUtils.blobliteral;
+import static org.alfasoftware.morf.sql.SqlUtils.blob;
 import static org.alfasoftware.morf.sql.SqlUtils.bracket;
 import static org.alfasoftware.morf.sql.SqlUtils.cast;
 import static org.alfasoftware.morf.sql.SqlUtils.field;
@@ -2165,8 +2165,8 @@ public abstract class AbstractSqlDialectTest {
   public void testUpdateWithLiteralValues() {
     UpdateStatement stmt = update(tableRef(TEST_TABLE))
       .set(literal("Value").as(STRING_FIELD))
-      .set(blobliteral(NEW_BLOB_VALUE).as("blobFieldOne"))
-      .set(blobliteral(NEW_BLOB_VALUE.getBytes(StandardCharsets.UTF_8)).as("blobFieldTwo"))
+      .set(blob(NEW_BLOB_VALUE).as("blobFieldOne"))
+      .set(blob(NEW_BLOB_VALUE.getBytes(StandardCharsets.UTF_8)).as("blobFieldTwo"))
       .where(and(
         field("field1").eq(true),
         field("field2").eq(false),
@@ -2176,8 +2176,8 @@ public abstract class AbstractSqlDialectTest {
         field("field6").eq(literal(new LocalDate(2010, 1, 2))),
         field("field7").eq("Value"),
         field("field8").eq(literal("Value")),
-        field("field9").eq(blobliteral(OLD_BLOB_VALUE)),
-        field("field10").eq(blobliteral(OLD_BLOB_VALUE.getBytes(StandardCharsets.UTF_8)))
+        field("field9").eq(blob(OLD_BLOB_VALUE)),
+        field("field10").eq(blob(OLD_BLOB_VALUE.getBytes(StandardCharsets.UTF_8)))
       ));
     assertEquals(
       "Update with literal values",

--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
@@ -250,8 +250,8 @@ public abstract class AbstractSqlDialectTest {
       + "zAuZmR4SwAAAAABATU=";
   private static final String NEW_BLOB_VALUE = "New Blob Value";
   private static final String OLD_BLOB_VALUE = "Old Blob Value";
-  protected static final String NEW_BLOB_VALUE_BASE64 = Base64.getEncoder().encodeToString(NEW_BLOB_VALUE.getBytes(StandardCharsets.UTF_8));
-  protected static final String OLD_BLOB_VALUE_BASE64 = Base64.getEncoder().encodeToString(NEW_BLOB_VALUE.getBytes(StandardCharsets.UTF_8));
+  protected static final String NEW_BLOB_VALUE_HEX = "4E657720426C6F622056616C7565";
+  protected static final String OLD_BLOB_VALUE_HEX = "4F6C6420426C6F622056616C7565";
 
 
   /**
@@ -4371,8 +4371,8 @@ public abstract class AbstractSqlDialectTest {
         tableName(TEST_TABLE),
         stringLiteralPrefix(),
         value,
-        expectedBlobLiteral(NEW_BLOB_VALUE),
-        expectedBlobLiteral(NEW_BLOB_VALUE),
+        expectedBlobLiteral(NEW_BLOB_VALUE_HEX),
+        expectedBlobLiteral(NEW_BLOB_VALUE_HEX),
         expectedBooleanLiteral(true),
         expectedBooleanLiteral(false),
         expectedBooleanLiteral(true),
@@ -4383,8 +4383,8 @@ public abstract class AbstractSqlDialectTest {
         value,
         stringLiteralPrefix(),
         value,
-        expectedBlobLiteral(OLD_BLOB_VALUE),
-        expectedBlobLiteral(OLD_BLOB_VALUE)
+        expectedBlobLiteral(OLD_BLOB_VALUE_HEX),
+        expectedBlobLiteral(OLD_BLOB_VALUE_HEX)
       );
   }
 
@@ -5226,7 +5226,7 @@ public abstract class AbstractSqlDialectTest {
    * @return The expected blob literal.
    */
   protected String expectedBlobLiteral(String value) {
-    return String.format("'%s'", Base64.getEncoder().encodeToString(value.getBytes(StandardCharsets.UTF_8)));
+    return String.format("'%s'", value);
   }
 
 

--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
@@ -112,7 +112,6 @@ import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Base64;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;


### PR DESCRIPTION
Fixed bloblength function to use the correct db function based on the dialect.
Also added support for blob literal value evaluation using the appropriate DB function.

Changes made to MySQL, Oracle and PostGreSQL dialects only as these are the only supported dialects as of now.

Blob literals store binary data in HEX format as most DBs support saving data to DB columns in HEX format.