### PR TITLE
Fixed OracleDialect.viewDeploymentStatementsAsLiteral(View) chunking.

### DIFF
--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -392,7 +392,7 @@ class OracleDialect extends SqlDialect {
     final String script = viewDeploymentStatementsAsScript(view);
 
     final int chunkSize = 512;
-    if (script.length() < chunkSize) {
+    if (script.length() <= chunkSize) {
       return super.viewDeploymentStatementsAsLiteral(view);
     }
 


### PR DESCRIPTION
OracleDialect.viewDeploymentStatementsAsLiteral(View) mistakenly tried to split a string which was exactly 1 chunk long (exactly 512 characters long view definition), resulting in a single chunk, resulting in concat complaining. View definitions which do not need to be (or cannot be) split into multiple chunks must take the shortcut to the parent implementation.