### PR TITLE
Increase H2 default lock timeout

### DIFF
--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2.java
@@ -88,7 +88,7 @@ public final class H2 extends AbstractDatabaseType {
     // The MV_STORE is a flag that governs whether to use the new storage engine (defaulting to true as of H2 version 1.4, false in prior versions)
     //  Note that implementations of H2 prior to version 1.4.199 had an MVCC parameter used to allow higher concurrency.
     //  This configuration has been removed and the old "PageStore" implementation (MV_STORE=FALSE) is no longer supported.
-    builder.append(";DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=60000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
+    builder.append(";DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=150000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
 
     return builder.toString();
   }


### PR DESCRIPTION
Increase the hardcoded default lock timeout from 60s to 150s after seeing some large inserts timing out. 