### PR TITLE
Increase H2 default lock timeout

### DIFF
--- a/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2.java
+++ b/morf-h2/src/main/java/org/alfasoftware/morf/jdbc/h2/H2.java
@@ -80,7 +80,7 @@ public final class H2 extends AbstractDatabaseType {
     }
 
     // The DB_CLOSE_DELAY=-1 prevents the database being lost when the last connection is closed.
-    // The DEFAULT_LOCK_TIMEOUT=60000 sets the default lock timeout to 60
+    // The DEFAULT_LOCK_TIMEOUT=150000 sets the default lock timeout to 150
     //    seconds. When the value is not set, it takes default
     //    org.h2.engine.Constants.INITIAL_LOCK_TIMEOUT=2000 value
     // The LOB_TIMEOUT defines how long a lob returned from a ResultSet is available post-commit, defaulting to 5 minutes (300000 ms)
@@ -88,7 +88,7 @@ public final class H2 extends AbstractDatabaseType {
     // The MV_STORE is a flag that governs whether to use the new storage engine (defaulting to true as of H2 version 1.4, false in prior versions)
     //  Note that implementations of H2 prior to version 1.4.199 had an MVCC parameter used to allow higher concurrency.
     //  This configuration has been removed and the old "PageStore" implementation (MV_STORE=FALSE) is no longer supported.
-    builder.append(";DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=60000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
+    builder.append(";DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=150000;LOB_TIMEOUT=2000;MV_STORE=TRUE");
 
     return builder.toString();
   }

--- a/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2DatabaseType.java
+++ b/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2DatabaseType.java
@@ -53,7 +53,7 @@ public class TestH2DatabaseType {
    */
   @Test
   public void testFormatJdbcUrl() {
-    String suffix = ";DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=60000;LOB_TIMEOUT=2000;MV_STORE=TRUE";
+    String suffix = ";DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=150000;LOB_TIMEOUT=2000;MV_STORE=TRUE";
 
     assertEquals("jdbc:h2:tcp://foo.com:123/mem:alfa" + suffix, databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withHost("foo.com").withPort(123).withDatabaseName("alfa").build()));
     assertEquals("jdbc:h2:tcp://foo.com/mem:alfa" + suffix, databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withHost("foo.com").withDatabaseName("alfa").build()));
@@ -63,7 +63,7 @@ public class TestH2DatabaseType {
     assertEquals("jdbc:h2:file:." + File.separator + "alfa" + suffix, databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withInstanceName(".").withDatabaseName("alfa").build()));
     assertEquals("jdbc:h2:file:bar" + File.separator + "alfa" + suffix, databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withInstanceName("bar" + File.separator).withDatabaseName("alfa").build()));
 
-    assertEquals("jdbc:h2:mem:data;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=60000;LOB_TIMEOUT=2000;MV_STORE=TRUE", databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withHost("localhost").withDatabaseName("data").build()));
+    assertEquals("jdbc:h2:mem:data;DB_CLOSE_DELAY=-1;DEFAULT_LOCK_TIMEOUT=150000;LOB_TIMEOUT=2000;MV_STORE=TRUE", databaseType.formatJdbcUrl(jdbcUrlElementBuilder().withHost("localhost").withDatabaseName("data").build()));
   }
 
 


### PR DESCRIPTION
Increase the hardcoded default lock timeout from 60s to 150s after seeing some large inserts timing out.