### PR TITLE
Fix Oracle parallel query hint syntax.

### DIFF
--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -55,8 +55,8 @@ import org.alfasoftware.morf.sql.UseImplicitJoinOrder;
 import org.alfasoftware.morf.sql.UseIndex;
 import org.alfasoftware.morf.sql.UseParallelDml;
 import org.alfasoftware.morf.sql.element.AliasedField;
-import org.alfasoftware.morf.sql.element.Cast;
 import org.alfasoftware.morf.sql.element.BlobFieldLiteral;
+import org.alfasoftware.morf.sql.element.Cast;
 import org.alfasoftware.morf.sql.element.ConcatenatedField;
 import org.alfasoftware.morf.sql.element.FieldReference;
 import org.alfasoftware.morf.sql.element.Function;
@@ -1282,7 +1282,7 @@ class OracleDialect extends SqlDialect {
       if (hint instanceof ParallelQueryHint) {
         builder.append(" PARALLEL");
         ParallelQueryHint parallelQueryHint = (ParallelQueryHint) hint;
-        builder.append(parallelQueryHint.getDegreeOfParallelism().map(d -> " " + d).orElse(""));
+        builder.append(parallelQueryHint.getDegreeOfParallelism().map(d -> "(" + d + ")").orElse(""));
       }
       if (hint instanceof OracleCustomHint) {
         builder.append(" ")

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -1506,7 +1506,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected String expectedHints6() {
-    return "SELECT /*+ PARALLEL 5 */ a, b FROM " + tableName("Foo") + " ORDER BY a NULLS FIRST";
+    return "SELECT /*+ PARALLEL(5) */ a, b FROM " + tableName("Foo") + " ORDER BY a NULLS FIRST";
   }
 
 


### PR DESCRIPTION
Fix Oracle PARALLEL query hint syntax.
`/*+ PARALLEL 4 */ `
should be instead:
`/*+ PARALLEL(4) */`