### PR TITLE
Default methods on ConnectionResources

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/AbstractConnectionResources.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/AbstractConnectionResources.java
@@ -138,43 +138,6 @@ public abstract class AbstractConnectionResources implements ConnectionResources
    */
   public abstract void setStatementPoolingMaxStatements(int statementPoolingMaxStatements);
 
-
-  /**
-   * The default behaviour for this method is interpreted as "not set" rather than 0. A default for this value is available at {@link SqlDialect#fetchSizeForBulkSelects()}.
-   * @see org.alfasoftware.morf.jdbc.ConnectionResources#getFetchSizeForBulkSelects()
-   */
-  @Override
-  public Integer getFetchSizeForBulkSelects(){
-    return null;
-  };
-
-
-  /**
-   * Sets the JDBC Fetch Size to use when performing bulk select operations, intended to replace the default in {@link SqlDialect#fetchSizeForBulkSelects()}.
-   *
-   * @param fetchSizeForBulkSelects the JDBC fetch size to use.
-   */
-  public void setFetchSizeForBulkSelects(Integer fetchSizeForBulkSelects){};
-
-
-  /**
-   * The default behaviour for this method is interpreted as "not set" rather than 0. A default for this value is available at {@link SqlDialect#fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming()}.
-   * @see org.alfasoftware.morf.jdbc.ConnectionResources#getFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming()
-   */
-  @Override
-  public Integer getFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming(){
-    return null;
-  };
-
-
-  /**
-   * Sets the JDBC Fetch Size to use when performing bulk select operations while allowing connection use, intended to replace the default in {@link SqlDialect#fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming()}.
-   *
-   * @param fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming the JDBC fetch size to use.
-   */
-  public void setFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming(Integer fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming){};
-
-
   /**
    * @return a formatted jdbc url string.
    */

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ConnectionResources.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ConnectionResources.java
@@ -107,23 +107,45 @@ public interface ConnectionResources {
    */
   public int getStatementPoolingMaxStatements();
 
-
   /**
    *
    * The JDBC Fetch Size to use when performing bulk select operations, intended to replace the default in {@link SqlDialect#fetchSizeForBulkSelects()}.
-   *
+   * The default behaviour for this method is interpreted as "not set" rather than 0.
    *  @return The number of rows to try and fetch at a time when
    *          performing bulk select operations.
    */
-  public Integer getFetchSizeForBulkSelects();
+  public default Integer getFetchSizeForBulkSelects(){
+    return null;
+  };
+
+  /**
+   * Sets the JDBC Fetch Size to use when performing bulk select operations, intended to replace the default in {@link SqlDialect#fetchSizeForBulkSelects()}.
+   * The default behaviour for this method is interpreted as not setting the value.
+   * @param fetchSizeForBulkSelects the JDBC fetch size to use.
+   */
+  public default void setFetchSizeForBulkSelects(Integer fetchSizeForBulkSelects){
+    // Default behavior is no-op
+  };
 
   /**
    *
    * The JDBC Fetch Size to use when performing bulk select operations while allowing connection use, intended to replace the default in {@link SqlDialect#fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming()}.
-   *
-   * @return The number of rows to try and fetch at a time (default) when
+   * The default behaviour for this method is interpreted as "not set" rather than 0.
+   *  @return The number of rows to try and fetch at a time (default) when
    *         performing bulk select operations and needing to use the connection while
    *         the {@link ResultSet} is open.
    */
-  public Integer getFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming();
+  public default Integer getFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming(){
+    return null;
+  };
+
+
+  /**
+   * Sets the JDBC Fetch Size to use when performing bulk select operations while allowing connection use, intended to replace the default in {@link SqlDialect#fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming()}.
+   * The default behaviour for this method is interpreted as not setting the value.
+   * @param fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming the JDBC fetch size to use.
+   */
+  public default void setFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming(Integer fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming){
+    // Default behavior is no-op
+  };
 }

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ConnectionResources.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ConnectionResources.java
@@ -116,7 +116,7 @@ public interface ConnectionResources {
    */
   public default Integer getFetchSizeForBulkSelects(){
     return null;
-  };
+  }
 
   /**
    * Sets the JDBC Fetch Size to use when performing bulk select operations, intended to replace the default in {@link SqlDialect#fetchSizeForBulkSelects()}.
@@ -136,7 +136,7 @@ public interface ConnectionResources {
    */
   public default Integer getFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming(){
     return null;
-  };
+  }
 
 
   /**

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ConnectionResources.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ConnectionResources.java
@@ -124,8 +124,7 @@ public interface ConnectionResources {
    * @param fetchSizeForBulkSelects the JDBC fetch size to use.
    */
   public default void setFetchSizeForBulkSelects(Integer fetchSizeForBulkSelects){
-    // Default behavior is no-op
-  };
+  }
 
   /**
    *
@@ -146,6 +145,5 @@ public interface ConnectionResources {
    * @param fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming the JDBC fetch size to use.
    */
   public default void setFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming(Integer fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming){
-    // Default behavior is no-op
-  };
+  }
 }


### PR DESCRIPTION
Moving default methods from AbstractConnectionResources to ConnectionResources to support full backwards compatibility