### PR TITLE
Adding support for legacy fetch size values

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -95,8 +95,8 @@ import org.joda.time.Months;
 import com.google.common.base.Joiner;
 import com.google.common.collect.FluentIterable;
 import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.ImmutableList.Builder;
+import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.Iterables;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Maps;
@@ -724,6 +724,20 @@ public abstract class SqlDialect {
 
 
   /**
+   * @deprecated this method returns the legacy value and is primarily for backwards compatibility.
+   * Please use {@link SqlDialect#fetchSizeForBulkSelects()} for the new recommended default value.
+   * @see SqlDialect#fetchSizeForBulkSelects()
+   *
+   * @return The number of rows to try and fetch at a time (default) when
+   *         performing bulk select operations.
+   */
+  @Deprecated
+  public int legacyFetchSizeForBulkSelects() {
+    return 1;
+  }
+
+
+  /**
    * When using a "streaming" {@link ResultSet} (i.e. any where the fetch size indicates that fewer
    * than all the records should be returned at a time), MySQL does not permit the connection
    * to be used for anything else.  Therefore we have an alternative fetch size here specifically
@@ -740,6 +754,20 @@ public abstract class SqlDialect {
    */
   public int fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming() {
     return fetchSizeForBulkSelects();
+  }
+
+
+  /**
+   * @deprecated this method returns the legacy value and is primarily for backwards compatibility.
+   * Please use {@link SqlDialect#fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming()} for the new recommended default value.
+   * @see SqlDialect#fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming()
+   *
+   * @return The number of rows to try and fetch at a time (default) when
+   *         performing bulk select operations.
+   */
+  @Deprecated
+  public int legacyFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming() {
+    return legacyFetchSizeForBulkSelects();
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlScriptExecutor.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlScriptExecutor.java
@@ -59,18 +59,23 @@ public class SqlScriptExecutor {
   private int fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming;
 
   /**
+   * @deprecated This constructor creates a {@link SqlScriptExecutor} with legacy fetch size values and is primarily for backwards compatibility.
+   * Please use {@link SqlScriptExecutor#SqlScriptExecutor(SqlScriptVisitor, DataSource, SqlDialect, ConnectionResources)} to create a
+   * {@link SqlScriptExecutor} with the new fetch size defaults or optional configured values.
+   *
    * Create an SQL executor with the given visitor, who will
    * be notified about events.
    *
    * @param visitor Visitor to notify about execution.
    * @param dataSource DataSource to use.
    */
+  @Deprecated
   SqlScriptExecutor(SqlScriptVisitor visitor, DataSource dataSource, SqlDialect sqlDialect) {
     super();
     this.dataSource = dataSource;
     this.sqlDialect = sqlDialect;
-    this.fetchSizeForBulkSelects = sqlDialect.fetchSizeForBulkSelects();
-    this.fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming = sqlDialect.fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming();
+    this.fetchSizeForBulkSelects = sqlDialect.legacyFetchSizeForBulkSelects();
+    this.fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming = sqlDialect.legacyFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming();
     this.visitor = checkVisitor(visitor);
   }
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/jdbc/TestSqlScriptExecutor.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/jdbc/TestSqlScriptExecutor.java
@@ -53,12 +53,14 @@ public class TestSqlScriptExecutor {
   }
 
   /**
-   * Verify that each {@link SqlScriptExecutor} sets the correct fetch sizes {@link java.sql.PreparedStatement}.
+   * Verify that a {@link SqlScriptExecutor} instantiated without ConnectionResources sets the legacy fetch sizes on {@link java.sql.PreparedStatement}.
    */
   @Test
-  public void testDefaultFetchSizesForSqlScriptExecutor() throws SQLException {
-    verify(sqlDialect, times(1)).fetchSizeForBulkSelects();
-    verify(sqlDialect, times(1)).fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming();
+  public void testLegacyFetchSizesForSqlScriptExecutor() throws SQLException {
+    verify(sqlDialect, times(0)).fetchSizeForBulkSelects();
+    verify(sqlDialect, times(0)).fetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming();
+    verify(sqlDialect, times(1)).legacyFetchSizeForBulkSelects();
+    verify(sqlDialect, times(1)).legacyFetchSizeForBulkSelectsAllowingConnectionUseDuringStreaming();
   }
 
 
@@ -87,7 +89,7 @@ public class TestSqlScriptExecutor {
 
 
   /**
-   * Verify that a {@link SqlScriptExecutor} instanstiated with no fetch sizes configured with ConnectionResources sets the default fetch sizes {@link java.sql.PreparedStatement}.
+   * Verify that a {@link SqlScriptExecutor} constructed with no fetch sizes configured on ConnectionResources sets the default fetch sizes on {@link java.sql.PreparedStatement}.
    */
   @Test
   public void testConnectionResourcesWithoutFetchSizesForSqlScriptExecutor() throws SQLException {

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -1341,6 +1341,18 @@ class OracleDialect extends SqlDialect {
 
 
   /**
+   * @deprecated this method returns the legacy fetch size value for Oracle and is primarily for backwards compatibility.
+   * Please use {@link SqlDialect#fetchSizeForBulkSelects()} for the new recommended default value.
+   * @see SqlDialect#fetchSizeForBulkSelects()
+   */
+  @Override
+  @Deprecated
+  public int legacyFetchSizeForBulkSelects() {
+    return 200;
+  }
+
+  
+  /**
    * We do use NVARCHAR for strings on Oracle.
    *
    * @see org.alfasoftware.morf.jdbc.SqlDialect#usesNVARCHARforStrings()


### PR DESCRIPTION
Adding support for legacy fetch size values in SqlDialect to de-risk scenarios where the new default fetch size cannot be overidden

Update SqlScriptExecutor to set legacy fetch size values if created without ConnectionResources, meaning the fetch size cannot be configured with ConnectionResources

Deprecating legacy fetch size methods