### PR TITLE
Drop tables first before dropping views

### DIFF
--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/testing/DatabaseSchemaManager.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/testing/DatabaseSchemaManager.java
@@ -148,12 +148,12 @@ public class DatabaseSchemaManager {
 
       Collection<String> sql = Lists.newLinkedList();
 
-      for (View view : changes.getViewsToDrop()) {
-        sql.addAll(dropViewIfExists(view));
-      }
-
       for (View view : changes.getViewsToDeploy()) {
         sql.addAll(dropTableIfPresent(producerCache, view.getName()));
+      }
+
+      for (View view : changes.getViewsToDrop()) {
+        sql.addAll(dropViewIfExists(view));
       }
 
 


### PR DESCRIPTION
This is to fix test failures in the reporting schema module when all are run together. The database is finding views and tables with the same name and then fails with the SQL execution. See WEB-157455 for full details.