### PR TITLE
Expose API to allow for separate verification of upgrade step properties

### DIFF
--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/testing/UpgradeTestHelper.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/testing/UpgradeTestHelper.java
@@ -181,10 +181,7 @@ public class UpgradeTestHelper {
    * For example UUID, Sequence, JIRA ID and Description are all populated.
    */
   public void validateUpgradeStepProperties(Iterable<Class<? extends UpgradeStep>> upgradeSteps) {
-    if (upgradeSteps instanceof Collection) {
-      instantiateAndValidateUpgradeSteps((Collection<Class<? extends UpgradeStep>>)upgradeSteps);
-    }
-    instantiateAndValidateUpgradeSteps(Streams.stream(upgradeSteps).collect(Collectors.toSet()));
+    instantiateAndValidateUpgradeSteps(upgradeSteps);
   }
 
 
@@ -245,8 +242,8 @@ public class UpgradeTestHelper {
   /**
    * Turn the list of classes into a list of objects.
    */
-  private List<UpgradeStep> instantiateAndValidateUpgradeSteps(Collection<Class<? extends UpgradeStep>> stepClasses) {
-    return stepClasses.stream()
+  private List<UpgradeStep> instantiateAndValidateUpgradeSteps(Iterable<Class<? extends UpgradeStep>> stepClasses) {
+    return Streams.stream(stepClasses)
         .map(stepClass -> {
           UpgradeStep upgradeStep;
           try {

--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/testing/UpgradeTestHelper.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/testing/UpgradeTestHelper.java
@@ -15,6 +15,7 @@
 
 package org.alfasoftware.morf.testing;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -26,6 +27,7 @@ import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 
 import org.alfasoftware.morf.jdbc.ConnectionResources;
 import org.alfasoftware.morf.jdbc.DatabaseDataSetProducer;
@@ -44,11 +46,10 @@ import org.alfasoftware.morf.upgrade.UpgradeGraph;
 import org.alfasoftware.morf.upgrade.UpgradeStep;
 import org.apache.commons.lang3.StringUtils;
 
-import com.google.common.base.Function;
 import com.google.common.base.Joiner;
-import com.google.common.collect.FluentIterable;
 import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
+import com.google.common.collect.Streams;
 import com.google.inject.Inject;
 import com.google.inject.Provider;
 
@@ -176,6 +177,18 @@ public class UpgradeTestHelper {
 
 
   /**
+   * Validate that each upgrade step meets the basic requirements.
+   * For example UUID, Sequence, JIRA ID and Description are all populated.
+   */
+  public void validateUpgradeStepProperties(Iterable<Class<? extends UpgradeStep>> upgradeSteps) {
+    if (upgradeSteps instanceof Collection) {
+      instantiateAndValidateUpgradeSteps((Collection<Class<? extends UpgradeStep>>)upgradeSteps);
+    }
+    instantiateAndValidateUpgradeSteps(Streams.stream(upgradeSteps).collect(Collectors.toSet()));
+  }
+
+
+  /**
    * Validate that the upgrade step meets the basic requirements.
    */
   private void validateUpgradeStep(UpgradeStep upgradeStep) {
@@ -183,40 +196,35 @@ public class UpgradeTestHelper {
 
     // Check the upgrade step has a Sequence
     if (upgradeStepClass.getAnnotation(Sequence.class) == null) {
-      fail("Upgrade step [" + upgradeStepClass.getName() + "] should have a Sequence set. How about ["
-          + System.currentTimeMillis() / 1000 + "]");
+      fail(String.format("Upgrade step [%s] should have a Sequence set. How about [%d]",
+        upgradeStepClass.getSimpleName(), System.currentTimeMillis() / 1000));
     }
     // Check the upgrade step has a UUID
     UUID uuidAnnotation = upgradeStepClass.getAnnotation(UUID.class);
     String currentUuid = uuidAnnotation == null ? null : uuidAnnotation.value();
 
     if (StringUtils.isBlank(currentUuid) || !uuids.add(currentUuid)) {
-      fail("Upgrade step [" + upgradeStepClass + "] should have a non blank, unique UUID set. How about ["
-          + java.util.UUID.randomUUID().toString() + "]");
+      fail(String.format("Upgrade step [%s] should have a non blank, unique UUID set. How about [%s]",
+        upgradeStepClass.getSimpleName(), java.util.UUID.randomUUID().toString()));
     }
 
     // verify we can parse the UUID
     try {
       assertNotNull(java.util.UUID.fromString(currentUuid));
     } catch (Exception e) {
-      throw new RuntimeException("Could not parse UUID [" + currentUuid + "] from [" + upgradeStepClass+"]", e);
+      throw new RuntimeException(String.format("Could not parse UUID [%s] from [%s]", currentUuid, upgradeStepClass.getSimpleName()), e);
     }
 
     // Check the upgrade step has a description
     final String description = upgradeStep.getDescription();
-    assertTrue("Should have a description", StringUtils.isNotEmpty(description));
-    assertTrue("Description must not be more than 200 characters", description.length() <= 200);
+    assertTrue(String.format("[%s] should have a description", upgradeStepClass.getSimpleName()), StringUtils.isNotEmpty(description));
+    assertTrue(String.format("Description for [%s] must not be more than 200 characters", upgradeStepClass.getSimpleName()), description.length() <= 200);
+    assertFalse(String.format("Description for [%s] should not end with full stop", upgradeStepClass.getSimpleName()), description.endsWith("."));
 
-    // Descriptions should not end with full-stops
-    if (description.endsWith(".")) {
-      fail(String.format("Description for [%s] should not end with full stop - [%s]", upgradeStepClass.getSimpleName(),
-        description));
-    }
-
-    assertTrue("Should have a JIRA ID", StringUtils.isNotEmpty(upgradeStep.getJiraId()));
+    assertTrue(String.format("[%s] should have a JIRA ID", upgradeStepClass.getSimpleName()), StringUtils.isNotEmpty(upgradeStep.getJiraId()));
 
     for (String jiraId : StringUtils.split(upgradeStep.getJiraId(), ',')) {
-      assertTrue("Should be a valid JIRA ID [" + upgradeStep.getJiraId() + "]", jiraIdIsValid(jiraId));
+      assertTrue(String.format("[%s] should have a valid JIRA ID [%s]", upgradeStepClass.getSimpleName(), upgradeStep.getJiraId()), jiraIdIsValid(jiraId));
     }
   }
 
@@ -238,22 +246,22 @@ public class UpgradeTestHelper {
    * Turn the list of classes into a list of objects.
    */
   private List<UpgradeStep> instantiateAndValidateUpgradeSteps(Collection<Class<? extends UpgradeStep>> stepClasses) {
-    return FluentIterable.from(stepClasses).transform(new Function<Class<? extends UpgradeStep>, UpgradeStep>() {
-      @Override public UpgradeStep apply(Class<? extends UpgradeStep> stepClass) {
-        UpgradeStep upgradeStep;
-        try {
-          Constructor<? extends UpgradeStep> constructor = stepClass.getDeclaredConstructor();
-          // Permit package-protected classes
-          constructor.setAccessible(true);
-          upgradeStep = constructor.newInstance();
-        } catch (Exception e) {
-          throw new RuntimeException(e);
-        }
+    return stepClasses.stream()
+        .map(stepClass -> {
+          UpgradeStep upgradeStep;
+          try {
+            Constructor<? extends UpgradeStep> constructor = stepClass.getDeclaredConstructor();
+            // Permit package-protected classes
+            constructor.setAccessible(true);
+            upgradeStep = constructor.newInstance();
+          } catch (Exception e) {
+            throw new RuntimeException(e);
+          }
 
-        validateUpgradeStep(upgradeStep);
+          validateUpgradeStep(upgradeStep);
 
-        return upgradeStep;
-      }
-    }).toList();
+          return upgradeStep;
+        })
+      .collect(Collectors.toList());
   }
 }


### PR DESCRIPTION
Expose API to allow for separate verification of upgrade step properties.
Make failure messages consistent.
Remove FluentIterable in favour of standard Stream