### PR TITLE
Feature/morf 92 support for right pad function

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -2084,6 +2084,12 @@ public abstract class SqlDialect {
         }
         return getSqlForLeftPad(function.getArguments().get(0), function.getArguments().get(1), function.getArguments().get(2));
 
+      case RIGHT_PAD:
+        if (function.getArguments().size() != 3) {
+          throw new IllegalArgumentException("The RIGHT_PAD function should have three arguments. This function has " + function.getArguments().size());
+        }
+        return getSqlForRightPad(function.getArguments().get(0), function.getArguments().get(1), function.getArguments().get(2));
+
       case LAST_DAY_OF_MONTH:
         if (function.getArguments().size() != 1) {
           throw new IllegalArgumentException("The LAST_DAY_OF_MONTH function should have one argument. This function has " + function.getArguments().size());
@@ -2608,7 +2614,7 @@ public abstract class SqlDialect {
 
   /**
    * Converts the LEFT_PAD function into SQL. This is the same format used for
-   * H2, MySQL and Oracle. SqlServer implementation overrides this function.
+   * H2, MySQL, Oracle and PostgreSQL. SqlServer implementation overrides this function.
    *
    * @param field The field to pad
    * @param length The length of the padding
@@ -2617,6 +2623,20 @@ public abstract class SqlDialect {
    */
   protected String getSqlForLeftPad(AliasedField field, AliasedField length, AliasedField character) {
     return "LPAD(" + getSqlFrom(field) + ", " + getSqlFrom(length) + ", " + getSqlFrom(character) + ")";
+  }
+
+
+  /**
+   * Converts the RIGHT_PAD function into SQL. This is the same format used for
+   * H2, MySQL, Oracle and PostgreSQL. SqlServer implementation overrides this function.
+   *
+   * @param field The field to pad
+   * @param length The length of the padding
+   * @param character The character to use for the padding
+   * @return string representation of the SQL.
+   */
+  protected String getSqlForRightPad(AliasedField field, AliasedField length, AliasedField character) {
+    return "RPAD(" + getSqlFrom(field) + ", " + getSqlFrom(length) + ", " + getSqlFrom(character) + ")";
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Function.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/Function.java
@@ -614,6 +614,21 @@ public final class Function extends AliasedField implements Driver {
 
 
   /**
+   * Helper method to create an instance of the <code>RPAD</code> SQL function.
+   * <p>Pads the <code>character</code> on the right of <code>field</code> so that the size equals <code>length</code></p>
+   * <p>The field should be of type {@link org.alfasoftware.morf.metadata.DataType#STRING}</p>
+   *
+   * @param field     String field to pad.
+   * @param length    target length.
+   * @param character character to pad.
+   * @return an instance of RPAD function.
+   */
+  public static Function rightPad(AliasedField field, AliasedField length, AliasedField character) {
+    return new Function(FunctionType.RIGHT_PAD, field, length, character);
+  }
+
+
+  /**
    * Convenience helper method to create an instance of the <code>LPAD</code> SQL function.
    * <p>Pads the <code>character</code> on the left of <code>field</code> so that the size equals <code>length</code></p>
    * <p>The field should be of type {@link org.alfasoftware.morf.metadata.DataType#STRING}</p>
@@ -625,6 +640,21 @@ public final class Function extends AliasedField implements Driver {
    */
   public static Function leftPad(AliasedField field, int length, String character) {
     return new Function(FunctionType.LEFT_PAD, field, literal(length), literal(character));
+  }
+
+
+  /**
+   * Convenience helper method to create an instance of the <code>RPAD</code> SQL function.
+   * <p>Pads the <code>character</code> on the right of <code>field</code> so that the size equals <code>length</code></p>
+   * <p>The field should be of type {@link org.alfasoftware.morf.metadata.DataType#STRING}</p>
+   *
+   * @param field     String field to pad.
+   * @param length    target length.
+   * @param character character to pad.
+   * @return an instance of RPAD function.
+   */
+  public static Function rightPad(AliasedField field, int length, String character) {
+    return new Function(FunctionType.RIGHT_PAD, field, literal(length), literal(character));
   }
 
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FunctionType.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/FunctionType.java
@@ -199,6 +199,11 @@ public enum FunctionType {
   LEFT_PAD,
 
   /**
+   * Right Pad function. Pads the specified character on the right of specified field to stretch it to the length specified.
+   */
+  RIGHT_PAD,
+
+  /**
    * Length function.
    */
   LENGTH,

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/HumanReadableStatementHelper.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/HumanReadableStatementHelper.java
@@ -116,6 +116,7 @@ class HumanReadableStatementHelper {
       .put(FunctionType.FLOOR, new FunctionTypeMetaData("floor(", ")", "", false, false))
       .put(FunctionType.IS_NULL, new FunctionTypeMetaData("", " if null", " or ", true, false))
       .put(FunctionType.LEFT_PAD, new FunctionTypeMetaData("leftPad(", ")", ", ", false, false))
+      .put(FunctionType.RIGHT_PAD, new FunctionTypeMetaData("rightPad(", ")", ", ", false, false))
       .put(FunctionType.LEFT_TRIM, new FunctionTypeMetaData("left trimmed ", "", "", false, false))
       .put(FunctionType.LENGTH, new FunctionTypeMetaData("length of ", "", "", false, false))
       .put(FunctionType.BLOB_LENGTH, new FunctionTypeMetaData("length of blob ", "", "", false, false))

--- a/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFunctionDetail.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/sql/element/TestFunctionDetail.java
@@ -237,6 +237,30 @@ public class TestFunctionDetail {
 
 
   /**
+   * Tests the indirect usage of rightPad
+   */
+  @Test
+  public void testRightPad() {
+    Function function = Function.rightPad(new FieldReference("invoiceNumber"), new FieldLiteral(10), new FieldLiteral('j'));
+
+    assertEquals("Function must be of type RIGHT_PAD", FunctionType.RIGHT_PAD, function.getType());
+    assertEquals("Function should have 3 arguments", 3, function.getArguments().size());
+  }
+
+
+  /**
+   * Tests the indirect usage of rightPad
+   */
+  @Test
+  public void testRightPadConvenientMethod() {
+    Function function = Function.rightPad(new FieldReference("invoiceNumber"), 10, "j");
+
+    assertEquals("Function must be of type RIGHT_PAD", FunctionType.RIGHT_PAD, function.getType());
+    assertEquals("Function should have 3 arguments", 3, function.getArguments().size());
+  }
+
+
+  /**
    * Tests indirect usage of the mod function
    */
   @Test

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestHumanReadableStatementHelper.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestHumanReadableStatementHelper.java
@@ -739,6 +739,7 @@ public class TestHumanReadableStatementHelper {
     final Function lowerCase = Function.lowerCase(new FieldReference("foo"));
     final Function upperCase = Function.upperCase(new FieldReference("foo"));
     final Function leftPad = Function.leftPad(new FieldReference("foo"), new FieldLiteral(32), new FieldLiteral(' '));
+    final Function rightPad = Function.rightPad(new FieldReference("foo"), new FieldLiteral(32), new FieldLiteral(' '));
     final Function now = Function.now();
     final Function lastDayOfMonth = Function.lastDayOfMonth(new FieldReference("foo"));
 
@@ -772,6 +773,7 @@ public class TestHumanReadableStatementHelper {
     assertEquals("LOWER_CASE", String.format("%n    - Set bar to lower case foo"), HumanReadableStatementHelper.generateAliasedFieldAssignmentString(lowerCase.as("bar")));
     assertEquals("UPPER_CASE", String.format("%n    - Set bar to upper case foo"), HumanReadableStatementHelper.generateAliasedFieldAssignmentString(upperCase.as("bar")));
     assertEquals("LEFT_PAD", String.format("%n    - Set bar to leftPad(foo, 32, ' ')"), HumanReadableStatementHelper.generateAliasedFieldAssignmentString(leftPad.as("bar")));
+    assertEquals("RIGHT_PAD", String.format("%n    - Set bar to rightPad(foo, 32, ' ')"), HumanReadableStatementHelper.generateAliasedFieldAssignmentString(rightPad.as("bar")));
     assertEquals("NOW", String.format("%n    - Set bar to now"), HumanReadableStatementHelper.generateAliasedFieldAssignmentString(now.as("bar")));
     assertEquals("LAST_DAY_OF_MONTH", String.format("%n    - Set bar to last day of month foo"), HumanReadableStatementHelper.generateAliasedFieldAssignmentString(lastDayOfMonth.as("bar")));
   }

--- a/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
+++ b/morf-h2/src/test/java/org/alfasoftware/morf/jdbc/h2/TestH2Dialect.java
@@ -32,10 +32,10 @@ import com.google.common.collect.ImmutableList;
  * @author Copyright (c) Alfa Financial Software 2010
  */
 public class TestH2Dialect extends AbstractSqlDialectTest {
-  
-  
+
+
   private final static String TEST_SCHEMA = "TESTSCHEMA";
-  
+
 
   /**
    * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#createTestDialect()
@@ -436,6 +436,15 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
   @Override
   protected String expectedLeftPad() {
     return "SELECT LPAD(stringField, 10, CAST('j' AS VARCHAR(1))) FROM "+TEST_SCHEMA+".Test";
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRightPad()
+   */
+  @Override
+  protected String expectedRightPad() {
+    return "SELECT RPAD(stringField, 10, CAST('j' AS VARCHAR(1))) FROM "+TEST_SCHEMA+".Test";
   }
 
 
@@ -1157,6 +1166,7 @@ public class TestH2Dialect extends AbstractSqlDialectTest {
   }
 
 
+  @Override
   protected List<String> expectedReplaceTableWithAutonumber() {
     return ImmutableList.of(
         "CREATE TABLE "+TEST_SCHEMA+".tmp_SomeTable (someField VARCHAR(3) NOT NULL, otherField DECIMAL(3,0) AUTO_INCREMENT(1) COMMENT 'AUTONUMSTART:[1]', thirdField DECIMAL(5,0) NOT NULL, CONSTRAINT tmp_SomeTable_PK PRIMARY KEY (someField))",

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -45,10 +45,8 @@ import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.metadata.SchemaUtils;
 import org.alfasoftware.morf.sql.CustomHint;
 import org.alfasoftware.morf.sql.OracleCustomHint;
-import org.alfasoftware.morf.sql.element.ClobFieldLiteral;
 import org.alfasoftware.morf.sql.element.Direction;
 import org.alfasoftware.morf.sql.element.SqlParameter;
-import org.junit.Test;
 import org.mockito.ArgumentCaptor;
 
 import com.google.common.base.Strings;
@@ -1460,6 +1458,15 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
   @Override
   protected String expectedLeftPad() {
     return "SELECT LPAD(stringField, 10, N'j') FROM TESTSCHEMA.Test";
+  }
+
+
+  /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRightPad()
+   */
+  @Override
+  protected String expectedRightPad() {
+    return "SELECT RPAD(stringField, 10, N'j') FROM TESTSCHEMA.Test";
   }
 
 

--- a/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
+++ b/morf-sqlserver/src/main/java/org/alfasoftware/morf/jdbc/sqlserver/SqlServerDialect.java
@@ -877,6 +877,27 @@ class SqlServerDialect extends SqlDialect {
 
 
   /**
+   * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForRightPad(org.alfasoftware.morf.sql.element.AliasedField, org.alfasoftware.morf.sql.element.AliasedField, org.alfasoftware.morf.sql.element.AliasedField)
+   */
+  @Override
+  protected String getSqlForRightPad(AliasedField field, AliasedField length, AliasedField character) {
+    String strField = getSqlFrom(field);
+    String strLength = getSqlFrom(length);
+    String strCharacter = getSqlFrom(character);
+
+    return String.format("CASE " +
+                           "WHEN LEN(%s) > %s THEN " +
+                             "LEFT(%s, %s) " +
+                           "ELSE " +
+                             "RIGHT(%s + REPLICATE(%s, %s), %s) " +
+                         "END",
+                         strField, strLength,
+                         strField, strLength,
+                         strField, strCharacter, strLength, strLength);
+  }
+
+
+  /**
    * @see org.alfasoftware.morf.jdbc.SqlDialect#getSqlForOrderByField(org.alfasoftware.morf.sql.element.FieldReference)
    */
   @Override

--- a/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
+++ b/morf-sqlserver/src/test/java/org/alfasoftware/morf/jdbc/sqlserver/TestSqlServerDialect.java
@@ -1211,6 +1211,15 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
 
 
   /**
+   * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedRightPad()
+   */
+  @Override
+  protected String expectedRightPad() {
+    return "SELECT CASE WHEN LEN(stringField) > 10 THEN LEFT(stringField, 10) ELSE RIGHT(stringField + REPLICATE('j', 10), 10) END FROM TESTSCHEMA.Test";
+  }
+
+
+  /**
    * @see org.alfasoftware.morf.jdbc.AbstractSqlDialectTest#expectedSelectOrderByNullsLast()
    */
   @Override
@@ -1268,6 +1277,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
   }
 
 
+  @Override
   protected List<String> expectedReplaceTableFromStatements() {
     return ImmutableList.of(
         "CREATE TABLE TESTSCHEMA.tmp_SomeTable ([someField] NVARCHAR(3) COLLATE SQL_Latin1_General_CP1_CS_AS NOT NULL, [otherField] NUMERIC(3,0) NOT NULL, [thirdField] NUMERIC(5,0) NOT NULL, CONSTRAINT [tmp_SomeTable_PK] PRIMARY KEY ([someField]))",
@@ -1281,6 +1291,7 @@ public class TestSqlServerDialect extends AbstractSqlDialectTest {
   }
 
 
+  @Override
   protected List<String> expectedReplaceTableWithAutonumber() {
     return ImmutableList.of(
         "CREATE TABLE TESTSCHEMA.tmp_SomeTable ([someField] NVARCHAR(3) COLLATE SQL_Latin1_General_CP1_CS_AS NOT NULL, [otherField] NUMERIC(3,0) NOT NULL IDENTITY(1, 1), [thirdField] NUMERIC(5,0) NOT NULL, CONSTRAINT [tmp_SomeTable_PK] PRIMARY KEY ([someField]))",

--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
@@ -79,6 +79,7 @@ import static org.alfasoftware.morf.sql.element.Function.now;
 import static org.alfasoftware.morf.sql.element.Function.power;
 import static org.alfasoftware.morf.sql.element.Function.random;
 import static org.alfasoftware.morf.sql.element.Function.randomString;
+import static org.alfasoftware.morf.sql.element.Function.rightPad;
 import static org.alfasoftware.morf.sql.element.Function.rightTrim;
 import static org.alfasoftware.morf.sql.element.Function.round;
 import static org.alfasoftware.morf.sql.element.Function.rowNumber;
@@ -3580,6 +3581,22 @@ public abstract class AbstractSqlDialectTest {
 
 
   /**
+   * Tests that the Left pad works.
+   */
+  @Test
+  public void testGetSqlForRightPad() {
+    // Given
+    Function rightPad = rightPad(new FieldReference(STRING_FIELD), new FieldLiteral(10), new FieldLiteral("j"));
+    SelectStatement leftPadStatement = new SelectStatement(rightPad).from(new TableReference(TEST_TABLE));
+
+    // When
+    String result = testDialect.convertStatementToSQL(leftPadStatement);
+
+    // Then
+    assertEquals("Right pad script must match the expected", expectedRightPad(), result);
+  }
+
+  /**
    * Tests the random function
    */
   @Test
@@ -5627,6 +5644,13 @@ public abstract class AbstractSqlDialectTest {
     return "SELECT LPAD(stringField, 10, 'j') FROM " + tableName(TEST_TABLE);
   }
 
+
+  /**
+   * @return the expected SQL for Left pad
+   */
+  protected String expectedRightPad() {
+    return "SELECT RPAD(stringField, 10, 'j') FROM " + tableName(TEST_TABLE);
+  }
 
   /**
    * @return The expected SQL for the MOD operator.

--- a/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
+++ b/morf-testsupport/src/main/java/org/alfasoftware/morf/jdbc/AbstractSqlDialectTest.java
@@ -3581,16 +3581,16 @@ public abstract class AbstractSqlDialectTest {
 
 
   /**
-   * Tests that the Left pad works.
+   * Tests that the right pad works.
    */
   @Test
   public void testGetSqlForRightPad() {
     // Given
     Function rightPad = rightPad(new FieldReference(STRING_FIELD), new FieldLiteral(10), new FieldLiteral("j"));
-    SelectStatement leftPadStatement = new SelectStatement(rightPad).from(new TableReference(TEST_TABLE));
+    SelectStatement rightPadStatement = new SelectStatement(rightPad).from(new TableReference(TEST_TABLE));
 
     // When
-    String result = testDialect.convertStatementToSQL(leftPadStatement);
+    String result = testDialect.convertStatementToSQL(rightPadStatement);
 
     // Then
     assertEquals("Right pad script must match the expected", expectedRightPad(), result);


### PR DESCRIPTION
Support the right pad (rpad) function to fill up a string of specific length by a substring.

This behaviour mirrors that of the already implemented left pad (lpad).