### PR TITLE
MORF-96: Set default cache size for oracle sequences to 100000

### DIFF
--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleDialect.java
@@ -178,6 +178,8 @@ class OracleDialect extends SqlDialect {
     createSequenceStatement.append(schemaNamePrefix());
     createSequenceStatement.append(truncatedSequenceName);
 
+    createSequenceStatement.append(" CACHE 100000");
+
     if (sequence.isTemporary()) {
       createSequenceStatement.append(" SESSION");
     }

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleDialect.java
@@ -1206,7 +1206,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedCreateSequenceStatements() {
-    return Arrays.asList("CREATE SEQUENCE " + tableName("TestSequence") + " START WITH 1");
+    return Arrays.asList("CREATE SEQUENCE " + tableName("TestSequence") + " CACHE 100000 START WITH 1");
   }
 
 
@@ -1215,7 +1215,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedCreateTemporarySequenceStatements() {
-    return Arrays.asList("CREATE SEQUENCE " + tableName("TestSequence") + " SESSION START WITH 1");
+    return Arrays.asList("CREATE SEQUENCE " + tableName("TestSequence") + " CACHE 100000 SESSION START WITH 1");
   }
 
 
@@ -1225,7 +1225,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedCreateSequenceStatementsWithNoStartWith() {
-    return Arrays.asList("CREATE SEQUENCE " + tableName("TestSequence"));
+    return Arrays.asList("CREATE SEQUENCE " + tableName("TestSequence") + " CACHE 100000");
   }
 
 
@@ -1235,7 +1235,7 @@ public class TestOracleDialect extends AbstractSqlDialectTest {
    */
   @Override
   protected List<String> expectedCreateTemporarySequenceStatementsWithNoStartWith() {
-    return Arrays.asList("CREATE SEQUENCE " + tableName("TestSequence") + " SESSION");
+    return Arrays.asList("CREATE SEQUENCE " + tableName("TestSequence") + " CACHE 100000 SESSION");
   }
 
 


### PR DESCRIPTION
Update the creation of sequences for the Oracle dialect such that the cache size is large by default