### PR TITLE
Adding SchemaAutoHealer

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -4457,7 +4457,7 @@ public abstract class SqlDialect {
   /**
    * Returns any statements needed to automatically heal the given schema.
    *
-   * This healer is intended for automated database modifications transparent to the {@link Schema}.
+   * This healer is intended for automated database modifications not visible via the {@link Schema}.
    * For example the names of primary key indexes are not generally available via the {@link Schema},
    * and can therefore be healed via this method without disrupting the {@link Schema} contents.
    *

--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/SqlDialect.java
@@ -96,6 +96,7 @@ import org.alfasoftware.morf.sql.element.TableReference;
 import org.alfasoftware.morf.sql.element.WhenCondition;
 import org.alfasoftware.morf.sql.element.WindowFunction;
 import org.alfasoftware.morf.upgrade.ChangeColumn;
+import org.alfasoftware.morf.upgrade.SchemaAutoHealer;
 import org.alfasoftware.morf.util.ObjectTreeTraverser;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -4455,6 +4456,19 @@ public abstract class SqlDialect {
 
   /**
    * Returns any statements needed to automatically heal the given schema.
+   *
+   * This healer is intended for automated database modifications transparent to the {@link Schema}.
+   * For example the names of primary key indexes are not generally available via the {@link Schema},
+   * and can therefore be healed via this method without disrupting the {@link Schema} contents.
+   *
+   * On the other hand, the names of indexes are available via the {@link Schema}, changing them
+   * via this method would leave a database inconsistent with the contents of the {@link Schema},
+   * and therefore those cannot be auto-healed via this method.
+   *
+   * See {@link SchemaAutoHealer}, another type of a database auto-healer, which is intended to heal
+   * characteristics of the database visible in the {@link Schema}.
+   *
+   * Also note that this type of healer is dialect-specific, each dialect implements it separately.
    *
    * @param schemaResource Schema resource that can be examined.
    * @return List of statements to be run.

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/SchemaAutoHealer.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/SchemaAutoHealer.java
@@ -30,7 +30,7 @@ public interface SchemaAutoHealer {
   /**
    * Analyses given database schema,
    * and produces a set of statements to be run on the database
-   * to arrive at a healed version of the that schema.
+   * to arrive at a healed version of that schema.
    *
    * @param sourceSchema Schema to be healed
    * @return Healing statements to be run, and the resulting healed schema.

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/SchemaAutoHealer.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/SchemaAutoHealer.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 import org.alfasoftware.morf.jdbc.SqlDialect;
 import org.alfasoftware.morf.metadata.Schema;
+import org.alfasoftware.morf.metadata.SchemaResource;
 
 import com.google.common.collect.ImmutableList;
 
@@ -18,7 +19,7 @@ import com.google.common.collect.ImmutableList;
  * {@link Schema}, and therefore cannot be healed via this interface, because this interface does
  * not have access to such invisible characteristics of the database.
  *
- * See {@link org.alfasoftware.morf.jdbc.SqlDialect.getSchemaConsistencyStatements(SchemaResource)},
+ * See {@link org.alfasoftware.morf.jdbc.SqlDialect#getSchemaConsistencyStatements(SchemaResource)},
  * another type of a database auto-healer, which is intended to heal characteristics of the database
  * not visible in the {@link Schema}.
  *

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/SchemaAutoHealer.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/SchemaAutoHealer.java
@@ -1,0 +1,119 @@
+package org.alfasoftware.morf.upgrade;
+
+import java.util.List;
+
+import org.alfasoftware.morf.jdbc.SqlDialect;
+import org.alfasoftware.morf.metadata.Schema;
+
+import com.google.common.collect.ImmutableList;
+
+/**
+ * This healer is intended for automated database modifications visible via the {@link Schema}.
+ *
+ * For example the names of indexes are available via the {@link Schema}, therefore changing them
+ * requires both the DDL statements and also a modified {@link Schema}. This interface could be
+ * used for such auto-healing of names of indexes.
+ *
+ * On the other hand, the names of primary key indexes are not generally available via the
+ * {@link Schema}, and therefore cannot be healed via this interface, because this interface does
+ * not have access to such invisible characteristics of the database.
+ *
+ * See {@link org.alfasoftware.morf.jdbc.SqlDialect.getSchemaConsistencyStatements(SchemaResource)},
+ * another type of a database auto-healer, which is intended to heal characteristics of the database
+ * not visible in the {@link Schema}.
+ *
+ * Also note that this type of healer is dialect-agnostic, all dialects will get equally affected.
+ */
+public interface SchemaAutoHealer {
+
+  /**
+   * Analyses given database schema,
+   * and produces a set of statements to be run on the database
+   * to arrive at a healed version of the that schema.
+   *
+   * @param sourceSchema Schema to be healed
+   * @return Healing statements to be run, and the resulting healed schema.
+   */
+  public SchemaHealingResults analyseSchema(Schema sourceSchema);
+
+
+  /**
+   * Results of {@link SchemaAutoHealer#analyseSchema(Schema)}.
+   */
+  public interface SchemaHealingResults {
+
+    /**
+     * Statements required to be run on the database to arrive at {@link #getHealedSchema()}.
+     */
+    public List<String> getHealingStatements(SqlDialect dialect);
+
+    /**
+     * The auto-healed schema of the database, as it will be once the statements
+     * from {@link #getHealingStatements(SqlDialect)} are run on that database.
+     */
+    public Schema getHealedSchema();
+  }
+
+
+  /**
+   * Simply uses a no-op healer.
+   * By no-op, we mean non-healing: the input is passed through as output.
+   */
+  public static final class NoOp implements SchemaAutoHealer {
+
+    @Override
+    public SchemaHealingResults analyseSchema(Schema sourceSchema) {
+      return new SchemaHealingResults() {
+
+        @Override
+        public List<String> getHealingStatements(SqlDialect dialect) {
+          return ImmutableList.of();
+        }
+
+        @Override
+        public Schema getHealedSchema() {
+          return sourceSchema;
+        }
+      };
+    }
+  }
+
+
+  /**
+   * Combines two {@link SchemaAutoHealer}s to run the second one on the results of the first one.
+   */
+  public static final class Combining implements SchemaAutoHealer {
+
+    private final SchemaAutoHealer first;
+    private final SchemaAutoHealer second;
+
+    public Combining(SchemaAutoHealer first, SchemaAutoHealer second) {
+      this.first = first;
+      this.second = second;
+    }
+
+
+    @Override
+    public SchemaHealingResults analyseSchema(Schema sourceSchema) {
+      final SchemaHealingResults firstResults = first.analyseSchema(sourceSchema);
+      final SchemaHealingResults secondResults = second.analyseSchema(firstResults.getHealedSchema());
+
+      return new SchemaHealingResults() {
+
+        @Override
+        public List<String> getHealingStatements(SqlDialect dialect) {
+          return ImmutableList.<String>builder()
+              .addAll(firstResults.getHealingStatements(dialect))
+              .addAll(secondResults.getHealingStatements(dialect))
+              .build();
+        }
+
+        @Override
+        public Schema getHealedSchema() {
+          return secondResults.getHealedSchema();
+        }
+      };
+    }
+
+  }
+}

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/UpgradeConfigAndContext.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/UpgradeConfigAndContext.java
@@ -23,23 +23,56 @@ public class UpgradeConfigAndContext {
    */
   private SchemaChangeAdaptor schemaChangeAdaptor = new SchemaChangeAdaptor.NoOp();
 
+  /**
+   * A schema auto-healer to be used before upgrade.
+   */
+  private SchemaAutoHealer schemaAutoHealer = new SchemaAutoHealer.NoOp();
 
+
+  /**
+   * @see #exclusiveExecutionSteps
+   */
   public Set<String> getExclusiveExecutionSteps() {
     return exclusiveExecutionSteps;
   }
 
+  /**
+   * @see #exclusiveExecutionSteps
+   */
   public UpgradeConfigAndContext setExclusiveExecutionSteps(Set<String> exclusiveExecutionSteps) {
     this.exclusiveExecutionSteps = exclusiveExecutionSteps;
     return this;
   }
 
 
+  /**
+   * @see #schemaChangeAdaptor
+   */
   public SchemaChangeAdaptor getSchemaChangeAdaptor() {
     return schemaChangeAdaptor;
   }
 
+  /**
+   * @see #schemaChangeAdaptor
+   */
   public void setSchemaChangeAdaptor(SchemaChangeAdaptor schemaChangeAdaptor) {
     Preconditions.checkNotNull(schemaChangeAdaptor);
     this.schemaChangeAdaptor = schemaChangeAdaptor;
+  }
+
+
+  /**
+   * @see #schemaAutoHealer
+   */
+  public SchemaAutoHealer getSchemaAutoHealer() {
+    return schemaAutoHealer;
+  }
+
+  /**
+   * @see #schemaAutoHealer
+   */
+  public void setSchemaAutoHealer(SchemaAutoHealer schemaAutoHealer) {
+    Preconditions.checkNotNull(schemaAutoHealer);
+    this.schemaAutoHealer = schemaAutoHealer;
   }
 }

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestSchemaAutoHealer.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestSchemaAutoHealer.java
@@ -1,0 +1,41 @@
+package org.alfasoftware.morf.upgrade;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.alfasoftware.morf.jdbc.SqlDialect;
+import org.alfasoftware.morf.metadata.Schema;
+import org.alfasoftware.morf.upgrade.SchemaAutoHealer.Combining;
+import org.alfasoftware.morf.upgrade.SchemaAutoHealer.SchemaHealingResults;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import com.google.common.collect.ImmutableList;
+
+public class TestSchemaAutoHealer {
+
+  @Test
+  public void testCombiningSchemaAutoHealer() {
+
+    SqlDialect dialect = mock(SqlDialect.class);
+
+    Schema schema1 = mock(Schema.class);
+    Schema schema2 = mock(Schema.class);
+    Schema schema3 = mock(Schema.class);
+
+    SchemaAutoHealer first = mock(SchemaAutoHealer.class, Mockito.RETURNS_DEEP_STUBS);
+    when(first.analyseSchema(schema1).getHealedSchema()).thenReturn(schema2);
+    when(first.analyseSchema(schema1).getHealingStatements(dialect)).thenReturn(ImmutableList.of("SQL1", "SQL2", "SQL3"));
+
+    SchemaAutoHealer second = mock(SchemaAutoHealer.class, Mockito.RETURNS_DEEP_STUBS);
+    when(second.analyseSchema(schema2).getHealedSchema()).thenReturn(schema3);
+    when(second.analyseSchema(schema2).getHealingStatements(dialect)).thenReturn(ImmutableList.of("SQL4", "SQL5", "SQL5"));
+
+    Combining combined = new SchemaAutoHealer.Combining(first, second);
+    SchemaHealingResults results = combined.analyseSchema(schema1);
+
+    assertEquals(schema3, results.getHealedSchema());
+    assertEquals(ImmutableList.of("SQL1", "SQL2", "SQL3", "SQL4", "SQL5", "SQL5"), results.getHealingStatements(dialect));
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestSchemaChangeAdaptor.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestSchemaChangeAdaptor.java
@@ -1,0 +1,282 @@
+package org.alfasoftware.morf.upgrade;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import org.alfasoftware.morf.upgrade.SchemaChangeAdaptor.Combining;
+import org.junit.Test;
+
+public class TestSchemaChangeAdaptor {
+
+  @Test
+  public void testCombiningAddColumn() {
+    AddColumn change1 = mock(AddColumn.class);
+    AddColumn change2 = mock(AddColumn.class);
+    AddColumn change3 = mock(AddColumn.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningAddTable() {
+    AddTable change1 = mock(AddTable.class);
+    AddTable change2 = mock(AddTable.class);
+    AddTable change3 = mock(AddTable.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningRemoveTable() {
+    RemoveTable change1 = mock(RemoveTable.class);
+    RemoveTable change2 = mock(RemoveTable.class);
+    RemoveTable change3 = mock(RemoveTable.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningAddIndex() {
+    AddIndex change1 = mock(AddIndex.class);
+    AddIndex change2 = mock(AddIndex.class);
+    AddIndex change3 = mock(AddIndex.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningChangeColumn() {
+    ChangeColumn change1 = mock(ChangeColumn.class);
+    ChangeColumn change2 = mock(ChangeColumn.class);
+    ChangeColumn change3 = mock(ChangeColumn.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningRemoveColumn() {
+    RemoveColumn change1 = mock(RemoveColumn.class);
+    RemoveColumn change2 = mock(RemoveColumn.class);
+    RemoveColumn change3 = mock(RemoveColumn.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningRemoveIndex() {
+    RemoveIndex change1 = mock(RemoveIndex.class);
+    RemoveIndex change2 = mock(RemoveIndex.class);
+    RemoveIndex change3 = mock(RemoveIndex.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningChangeIndex() {
+    ChangeIndex change1 = mock(ChangeIndex.class);
+    ChangeIndex change2 = mock(ChangeIndex.class);
+    ChangeIndex change3 = mock(ChangeIndex.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningRenameIndex() {
+    RenameIndex change1 = mock(RenameIndex.class);
+    RenameIndex change2 = mock(RenameIndex.class);
+    RenameIndex change3 = mock(RenameIndex.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningExecuteStatement() {
+    ExecuteStatement change1 = mock(ExecuteStatement.class);
+    ExecuteStatement change2 = mock(ExecuteStatement.class);
+    ExecuteStatement change3 = mock(ExecuteStatement.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningRenameTable() {
+    RenameTable change1 = mock(RenameTable.class);
+    RenameTable change2 = mock(RenameTable.class);
+    RenameTable change3 = mock(RenameTable.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningChangePrimaryKeyColumns() {
+    ChangePrimaryKeyColumns change1 = mock(ChangePrimaryKeyColumns.class);
+    ChangePrimaryKeyColumns change2 = mock(ChangePrimaryKeyColumns.class);
+    ChangePrimaryKeyColumns change3 = mock(ChangePrimaryKeyColumns.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningAddTableFrom() {
+    AddTableFrom change1 = mock(AddTableFrom.class);
+    AddTableFrom change2 = mock(AddTableFrom.class);
+    AddTableFrom change3 = mock(AddTableFrom.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningAnalyseTable() {
+    AnalyseTable change1 = mock(AnalyseTable.class);
+    AnalyseTable change2 = mock(AnalyseTable.class);
+    AnalyseTable change3 = mock(AnalyseTable.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningAddSequence() {
+    AddSequence change1 = mock(AddSequence.class);
+    AddSequence change2 = mock(AddSequence.class);
+    AddSequence change3 = mock(AddSequence.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+
+
+  @Test
+  public void testCombiningRemoveSequence() {
+    RemoveSequence change1 = mock(RemoveSequence.class);
+    RemoveSequence change2 = mock(RemoveSequence.class);
+    RemoveSequence change3 = mock(RemoveSequence.class);
+
+    SchemaChangeAdaptor first = mock(SchemaChangeAdaptor.class);
+    when(first.adapt(change1)).thenReturn(change2);
+
+    SchemaChangeAdaptor second = mock(SchemaChangeAdaptor.class);
+    when(second.adapt(change2)).thenReturn(change3);
+
+    Combining combined = new SchemaChangeAdaptor.Combining(first, second);
+    assertEquals(change3, combined.adapt(change1));
+  }
+}

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestUpgrade.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestUpgrade.java
@@ -74,6 +74,7 @@ import org.alfasoftware.morf.sql.InsertStatement;
 import org.alfasoftware.morf.sql.SelectStatement;
 import org.alfasoftware.morf.upgrade.GraphBasedUpgradeBuilder.GraphBasedUpgradeBuilderFactory;
 import org.alfasoftware.morf.upgrade.MockConnectionResources.StubSchemaResource;
+import org.alfasoftware.morf.upgrade.SchemaAutoHealer.SchemaHealingResults;
 import org.alfasoftware.morf.upgrade.UpgradePath.UpgradePathFactory;
 import org.alfasoftware.morf.upgrade.db.DatabaseUpgradeTableContribution;
 import org.alfasoftware.morf.upgrade.testupgrade.upgrade.v1_0_0.ChangeCar;
@@ -192,28 +193,18 @@ public class TestUpgrade {
 
 
   /**
-   * Test {@link Upgrade}.
+   * Test {@link Upgrade} schema consistency auto-healing.
    */
   @Test
-  public void testUpgradeWithHealing() throws SQLException {
+  public void testUpgradeWithSchemaConsistencyHealing() throws SQLException {
     Table upgradeAudit = upgradeAudit();
 
     Table car = originalCar();
-    Table driver = table("Driver")
-        .columns(
-            idColumn(),
-            versionColumn(),
-            column("name", DataType.STRING, 10).nullable(),
-            column("address", DataType.STRING, 10).nullable()
-        );
-
     Table carUpgraded = upgradedCar();
 
     Schema targetSchema = schema(upgradeAudit, carUpgraded);
     Collection<Class<? extends UpgradeStep>> upgradeSteps = new ArrayList<>();
     upgradeSteps.add(ChangeCar.class);
-
-    List<Table> tables = Arrays.asList(upgradeAudit, car);
 
     ResultSet viewResultSet = mock(ResultSet.class);
     when(viewResultSet.next()).thenReturn(false);
@@ -224,19 +215,19 @@ public class TestUpgrade {
     when(upgradeResultSet.next()).thenReturn(false);
 
     SqlDialect dialect = spy(new MockDialect());
-    when(dialect.getSchemaConsistencyStatements(any(SchemaResource.class))).thenReturn(Lists.newArrayList("HEALING1", "HEALING2"));
-
     ConnectionResources mockConnectionResources = new MockConnectionResources().
         withResultSet("SELECT upgradeUUID FROM UpgradeAudit", upgradeResultSet).
         withResultSet("SELECT name, hash FROM DeployedViews", viewResultSet).
         withDialect(dialect).
         create();
 
-    SchemaResource schemaResource = mock(SchemaResource.class);
-    when(mockConnectionResources.openSchemaResource(eq(mockConnectionResources.getDataSource()))).thenReturn(schemaResource);
-    when(schemaResource.tables()).thenReturn(tables);
+    SchemaResource schemaResource = new StubSchemaResource(schema(ImmutableList.of(upgradeAudit, car)));
+    when(mockConnectionResources.openSchemaResource(mockConnectionResources.getDataSource())).thenReturn(schemaResource);
+
+    when(dialect.getSchemaConsistencyStatements(any(SchemaResource.class))).thenReturn(ImmutableList.of("HEALING1", "HEALING2"));
 
     UpgradePath results = new Upgrade.Factory(upgradePathFactory(), upgradeStatusTableServiceFactory(mockConnectionResources), viewChangesDeploymentHelperFactory(mockConnectionResources), viewDeploymentValidatorFactory(), databaseUpgradeLockServiceFactory(), graphBasedUpgradeScriptGeneratorFactory)
+        .withUpgradeConfiguration(upgradeConfigAndContext)
         .create(mockConnectionResources)
         .findPath(targetSchema, upgradeSteps, Lists.newArrayList(), mockConnectionResources.getDataSource());
 
@@ -248,6 +239,61 @@ public class TestUpgrade {
     assertEquals("Path validation SQL present.", "INIT", sql.get(0));
     assertEquals("Healing SQL 1.", "HEALING1", sql.get(1));
     assertEquals("Healing SQL 2.", "HEALING2", sql.get(2));
+  }
+
+
+  /**
+   * Test {@link Upgrade} schema-modifying auto-healing.
+   */
+  @Test
+  public void testUpgradeWithSchemaHealing() throws SQLException {
+    Table upgradeAudit = upgradeAudit();
+
+    Table car = originalCar();
+    Table carUpgraded = upgradedCar();
+
+    Schema targetSchema = schema(upgradeAudit, carUpgraded);
+    Collection<Class<? extends UpgradeStep>> upgradeSteps = new ArrayList<>();
+    upgradeSteps.add(ChangeCar.class);
+
+    ResultSet viewResultSet = mock(ResultSet.class);
+    when(viewResultSet.next()).thenReturn(false);
+
+    ResultSet upgradeResultSet = mock(ResultSet.class);
+    when(upgradeResultSet.next()).thenReturn(true, true, false);
+    when(upgradeResultSet.getString(1)).thenReturn("0fde0d93-f57e-405c-81e9-245ef1ba0594", "0fde0d93-f57e-405c-81e9-245ef1ba0595");
+    when(upgradeResultSet.next()).thenReturn(false);
+
+    SqlDialect dialect = spy(new MockDialect());
+    ConnectionResources mockConnectionResources = new MockConnectionResources().
+        withResultSet("SELECT upgradeUUID FROM UpgradeAudit", upgradeResultSet).
+        withResultSet("SELECT name, hash FROM DeployedViews", viewResultSet).
+        withDialect(dialect).
+        create();
+
+    SchemaResource schemaResource = new StubSchemaResource(schema(ImmutableList.of(upgradeAudit, carUpgraded))); // note: car already upgraded in source schema
+    when(mockConnectionResources.openSchemaResource(mockConnectionResources.getDataSource())).thenReturn(schemaResource);
+
+    SchemaHealingResults schemaHealingResults = mock (SchemaHealingResults.class);
+    when(schemaHealingResults.getHealingStatements(dialect)).thenReturn(ImmutableList.of("MODIFYING1", "MODIFYING2"));
+    when(schemaHealingResults.getHealedSchema()).thenReturn(schema(ImmutableList.of(upgradeAudit, car))); // note: make car not-upgraded again, in the modified schema, allowing the upgrade step to run
+    SchemaAutoHealer schemaAutoHealer = mock(SchemaAutoHealer.class);
+    when(schemaAutoHealer.analyseSchema(any())).thenReturn(schemaHealingResults);
+    upgradeConfigAndContext.setSchemaAutoHealer(schemaAutoHealer);
+
+    UpgradePath results = new Upgrade.Factory(upgradePathFactory(), upgradeStatusTableServiceFactory(mockConnectionResources), viewChangesDeploymentHelperFactory(mockConnectionResources), viewDeploymentValidatorFactory(), databaseUpgradeLockServiceFactory(), graphBasedUpgradeScriptGeneratorFactory)
+        .withUpgradeConfiguration(upgradeConfigAndContext)
+        .create(mockConnectionResources)
+        .findPath(targetSchema, upgradeSteps, Lists.newArrayList(), mockConnectionResources.getDataSource());
+
+    assertEquals("Should be one step.", 1, results.getSteps().size());
+    List<String> sql = results.getSql();
+    assertEquals("Number of SQL statements", 13, sql.size());
+
+    // The path validation SQL should be first, then the healing statements.
+    assertEquals("Path validation SQL present.", "INIT", sql.get(0));
+    assertEquals("Healing SQL 1.", "MODIFYING1", sql.get(1));
+    assertEquals("Healing SQL 2.", "MODIFYING2", sql.get(2));
   }
 
 


### PR DESCRIPTION
Notes:
- This new SchemaAutoHealer is for auto-healing the source Schema, as read from the database. It is dialect agnostic and can modify the source Schema.
- The older SqlDialect.getSchemaConsistencyStatements() is for auto-healing hidden inconsistencies within the database, which are invisible via the source Schema.