### PR TITLE
Improve ResultSetComparer

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ResultSetComparer.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/ResultSetComparer.java
@@ -423,7 +423,10 @@ public class ResultSetComparer {
       return resultSet.getString(columnIndex);
     } else if (columnTypeIsNumeric(columnType)) {
       BigDecimal bigDecimal = resultSet.getBigDecimal(columnIndex);
-      return bigDecimal == null ? null : bigDecimal.stripTrailingZeros();
+      if (bigDecimal == null || bigDecimal.scale() == 0) {
+        return bigDecimal;
+      }
+      return bigDecimal.stripTrailingZeros();
     } else if (columnTypeIsBoolean(columnType)) {
       return resultSet.getBoolean(columnIndex);
     } else if (columnTypeIsDate(columnType)) {

--- a/morf-core/src/main/java/org/alfasoftware/morf/metadata/DataType.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/metadata/DataType.java
@@ -76,7 +76,7 @@ public enum DataType {
 
   /**
    * @param hasWidth Whether this DataType has a variable width
-   * @param hasScale Whether this DataType has a variable width
+   * @param hasScale Whether this DataType has a variable scale
    */
   private DataType(boolean hasWidth, boolean hasScale) {
     this.hasWidth = hasWidth;
@@ -93,7 +93,7 @@ public enum DataType {
 
 
   /**
-   * @return Whether this DataType has a variable width
+   * @return Whether this DataType has a variable scale
    */
   public boolean hasScale() {
     return hasScale;

--- a/morf-core/src/main/java/org/alfasoftware/morf/sql/element/TableReference.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/sql/element/TableReference.java
@@ -139,10 +139,10 @@ public class TableReference implements DeepCopyableWithTransformation<TableRefer
    * Specifies the alias to use for the table.
    *
    * @param aliasName the name of the alias
-   * @return an updated {@link TableReference} (this will not be a new object)
+   * @return an updated {@link TableReference} (this will not be a new object unless using immutable DSL option and the alias is being changed)
    */
   public TableReference as(String aliasName) {
-    if (AliasedField.immutableDslEnabled()) {
+    if (AliasedField.immutableDslEnabled() && !aliasName.equals(alias)) {
       return new TableReference(this, aliasName);
     } else {
       this.alias = aliasName;


### PR DESCRIPTION
BigDecimal.stripTrailingZeros is inefficient even when there is no possible work to do (at least through J17), so shortcut this.

Minor correction to javadoc and improvement to tablereference aliasing.