### PR TITLE
Upgrading Guice dependency and removing javax.inject

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/DatabaseUpgradePathValidationServiceImpl.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/DatabaseUpgradePathValidationServiceImpl.java
@@ -10,8 +10,6 @@ import static org.alfasoftware.morf.sql.element.Function.count;
 
 import java.util.List;
 
-import javax.inject.Inject;
-
 import org.alfasoftware.morf.jdbc.ConnectionResources;
 import org.alfasoftware.morf.jdbc.SqlDialect;
 import org.alfasoftware.morf.sql.InsertStatement;
@@ -20,6 +18,7 @@ import org.alfasoftware.morf.sql.element.TableReference;
 import org.alfasoftware.morf.upgrade.db.DatabaseUpgradeTableContribution;
 
 import com.google.common.collect.ImmutableList;
+import com.google.inject.Inject;
 
 /**
  * Implementation of {@link DatabaseUpgradePathValidationService}

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/ViewChangesDeploymentHelper.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/ViewChangesDeploymentHelper.java
@@ -1,22 +1,23 @@
 package org.alfasoftware.morf.upgrade;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableList.Builder;
-import org.alfasoftware.morf.jdbc.ConnectionResources;
-import org.alfasoftware.morf.jdbc.SqlDialect;
-import org.alfasoftware.morf.metadata.View;
-import org.alfasoftware.morf.upgrade.db.DatabaseUpgradeTableContribution;
-
-import javax.inject.Inject;
-import java.util.List;
-
 import static org.alfasoftware.morf.metadata.SchemaUtils.schema;
 import static org.alfasoftware.morf.sql.SqlUtils.delete;
 import static org.alfasoftware.morf.sql.SqlUtils.field;
 import static org.alfasoftware.morf.sql.SqlUtils.insert;
 import static org.alfasoftware.morf.sql.SqlUtils.literal;
 import static org.alfasoftware.morf.sql.SqlUtils.tableRef;
+
+import java.util.List;
+
+import org.alfasoftware.morf.jdbc.ConnectionResources;
+import org.alfasoftware.morf.jdbc.SqlDialect;
+import org.alfasoftware.morf.metadata.View;
+import org.alfasoftware.morf.upgrade.db.DatabaseUpgradeTableContribution;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableList.Builder;
+import com.google.inject.Inject;
 
 /**
  * View deployment helper.

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/upgrade/TestDatabaseUpgradePathValidationService.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/upgrade/TestDatabaseUpgradePathValidationService.java
@@ -13,8 +13,6 @@ import static org.junit.Assert.assertTrue;
 import java.util.List;
 import java.util.Set;
 
-import javax.inject.Inject;
-
 import org.alfasoftware.morf.dataset.DataSetConnector;
 import org.alfasoftware.morf.dataset.DataSetProducer;
 import org.alfasoftware.morf.guicesupport.InjectMembersRule;
@@ -32,6 +30,8 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.MethodRule;
+
+import com.google.inject.Inject;
 
 /**
  * Test for {@link DatabaseUpgradePathValidationService}

--- a/pom.xml
+++ b/pom.xml
@@ -50,7 +50,7 @@
     <commons-codec.version>1.15</commons-codec.version>
     <commons-logging.version>1.2</commons-logging.version>
     <guava.version>32.0.0-jre</guava.version>
-    <guice.version>5.1.0</guice.version>
+    <guice.version>7.0.0</guice.version>
     <h2.version>1.4.200</h2.version>
     <hamcrest.version>1.3</hamcrest.version>
     <jcip-annotations.version>1.0</jcip-annotations.version>


### PR DESCRIPTION
Upgrading to Guice 7 will effectively ban javax.* in favour of google or jakarta equivalent.
Besides that Guice 7 is identical to Guice 6, which is currently used in alfasystems