### PR TITLE
the currentSchema on AbstractSchemaChangeVisitor must be shared with …

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/AbstractSchemaChangeVisitor.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/AbstractSchemaChangeVisitor.java
@@ -12,15 +12,15 @@ import org.alfasoftware.morf.metadata.Schema;
  */
 public abstract class AbstractSchemaChangeVisitor implements SchemaChangeVisitor {
 
-  protected Schema sourceSchema;
+  protected Schema     currentSchema;
   protected SqlDialect sqlDialect;
   protected final UpgradeConfigAndContext upgradeConfigAndContext;
 
   protected abstract void writeStatements(Collection<String> statements);
 
 
-  public AbstractSchemaChangeVisitor(Schema sourceSchema, UpgradeConfigAndContext upgradeConfigAndContext, SqlDialect sqlDialect) {
-    this.sourceSchema = sourceSchema;
+  public AbstractSchemaChangeVisitor(Schema currentSchema, UpgradeConfigAndContext upgradeConfigAndContext, SqlDialect sqlDialect) {
+    this.currentSchema = currentSchema;
     this.upgradeConfigAndContext = upgradeConfigAndContext;
     this.sqlDialect = sqlDialect;
   }
@@ -28,7 +28,7 @@ public abstract class AbstractSchemaChangeVisitor implements SchemaChangeVisitor
 
   @Override
   public void visit(AddIndex addIndex) {
-    sourceSchema = addIndex.apply(sourceSchema);
+    currentSchema = addIndex.apply(currentSchema);
     Index foundIndex = null;
     List<Index> ignoredIndexes = upgradeConfigAndContext.getIgnoredIndexesForTable(addIndex.getTableName());
     for (Index index : ignoredIndexes) {
@@ -39,9 +39,9 @@ public abstract class AbstractSchemaChangeVisitor implements SchemaChangeVisitor
     }
 
     if (foundIndex != null) {
-      writeStatements(sqlDialect.renameIndexStatements(sourceSchema.getTable(addIndex.getTableName()), foundIndex.getName(), addIndex.getNewIndex().getName()));
+      writeStatements(sqlDialect.renameIndexStatements(currentSchema.getTable(addIndex.getTableName()), foundIndex.getName(), addIndex.getNewIndex().getName()));
     } else {
-      writeStatements(sqlDialect.addIndexStatements(sourceSchema.getTable(addIndex.getTableName()), addIndex.getNewIndex()));
+      writeStatements(sqlDialect.addIndexStatements(currentSchema.getTable(addIndex.getTableName()), addIndex.getNewIndex()));
     }
   }
 

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/InlineTableUpgrader.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/InlineTableUpgrader.java
@@ -31,7 +31,6 @@ import org.alfasoftware.morf.sql.Statement;
  */
 public class InlineTableUpgrader extends AbstractSchemaChangeVisitor implements SchemaChangeVisitor {
 
-  private Schema                   currentSchema;
   private final SqlStatementWriter sqlStatementWriter;
   private final Table              idTable;
   private final TableNameResolver  tracker;


### PR DESCRIPTION
…both inheritors as it would be redefined and reused as upgrade steps progress.