### PR TITLE
Treat no-operation upgrade nodes as non-exclusive

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/GraphBasedUpgradeNode.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/GraphBasedUpgradeNode.java
@@ -134,7 +134,7 @@ public class GraphBasedUpgradeNode {
    *         node should be executed while this one is being processed)
    */
   public boolean requiresExclusiveExecution() {
-    return exclusiveExecution || reads.isEmpty() && modifies.isEmpty();
+    return exclusiveExecution || isRoot();
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestGraphBasedUpgradeBuilder.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestGraphBasedUpgradeBuilder.java
@@ -353,7 +353,7 @@ public class TestGraphBasedUpgradeBuilder {
   public void testExclusiveNodeNotAParent() {
     // given
     when(upgradeTableResolution.getModifiedTables(U1000.class.getName())).thenReturn(Sets.newHashSet("t1"));
-    when(upgradeTableResolution.getModifiedTables(U1000.class.getName())).thenReturn(Sets.newHashSet("t1", "t2"));
+    when(upgradeTableResolution.getModifiedTables(U1001.class.getName())).thenReturn(Sets.newHashSet("t1", "t2"));
     upgradeSteps.addAll(Lists.newArrayList(eu1, u1000, u1001));
 
     // when


### PR DESCRIPTION
When an upgrade step has no read actions and no modify actions (for example where it has been blanked out and replaced due to issues found) Morf was still treating it as requiring exclusive execution. Instead, treat it as a normal node which can be parallelised in the graph based upgrade, speeding up end-to-end upgrade execution.
MORF-122