### PR TITLE
Add support for renaming PRF indexes on changeIndex.

### DIFF
--- a/morf-core/src/main/java/org/alfasoftware/morf/jdbc/DatabaseMetaDataProvider.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/jdbc/DatabaseMetaDataProvider.java
@@ -46,6 +46,7 @@ import org.alfasoftware.morf.metadata.Sequence;
 import org.alfasoftware.morf.metadata.Table;
 import org.alfasoftware.morf.metadata.View;
 import org.alfasoftware.morf.sql.SelectStatement;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
@@ -814,8 +815,10 @@ public abstract class DatabaseMetaDataProvider implements Schema {
             }
 
             String dbColumnName = indexResultSet.getString(INDEX_COLUMN_NAME);
-            String realColumnName = allColumns.get().get(tableName).get(named(dbColumnName)).getName();
+            ColumnBuilder columnFound = allColumns.get().get(tableName).getOrDefault(named(dbColumnName), null);
+            String realColumnName = columnFound == null ? "" : columnFound.getName();
             RealName columnName = createRealName(dbColumnName, realColumnName);
+
             boolean unique = !indexResultSet.getBoolean(INDEX_NON_UNIQUE);
 
             if (log.isDebugEnabled()) {
@@ -825,9 +828,18 @@ public abstract class DatabaseMetaDataProvider implements Schema {
             indexUniqueness.put(indexName, unique);
 
             if  (DatabaseMetaDataProviderUtils.shouldIgnoreIndex(indexName.getDbName())) {
-              ignoredIndexColumns.computeIfAbsent(indexName, k -> ImmutableList.builder())
-                .add(columnName);
+              if (StringUtils.isEmpty(realColumnName)) {
+                if (log.isDebugEnabled()) {
+                  log.debug("Found ignored index column expression [" + dbColumnName + "] for index [" + indexName  + ", unique: " + unique + "] on table [" + tableName + "]");
+                }
+              } else {
+                ignoredIndexColumns.computeIfAbsent(indexName, k -> ImmutableList.builder())
+                    .add(columnName);
+              }
             } else {
+              if (StringUtils.isEmpty(realColumnName)) {
+                throw new IllegalArgumentException("Found a column that is an expression in an index.");
+              }
               indexColumns.computeIfAbsent(indexName, k -> ImmutableList.builder())
                 .add(columnName);
             }

--- a/morf-core/src/main/java/org/alfasoftware/morf/upgrade/AbstractSchemaChangeVisitor.java
+++ b/morf-core/src/main/java/org/alfasoftware/morf/upgrade/AbstractSchemaChangeVisitor.java
@@ -101,8 +101,23 @@ public abstract class AbstractSchemaChangeVisitor implements SchemaChangeVisitor
   @Override
   public void visit(ChangeIndex changeIndex) {
     currentSchema = changeIndex.apply(currentSchema);
-    writeStatements(sqlDialect.indexDropStatements(currentSchema.getTable(changeIndex.getTableName()), changeIndex.getFromIndex()));
-    writeStatements(sqlDialect.addIndexStatements(currentSchema.getTable(changeIndex.getTableName()), changeIndex.getToIndex()));
+
+    Index foundIndex = null;
+    List<Index> ignoredIndexes = upgradeConfigAndContext.getIgnoredIndexesForTable(changeIndex.getTableName());
+    for (Index index : ignoredIndexes) {
+      if (index.columnNames().equals(changeIndex.getToIndex().columnNames()) && index.isUnique() == changeIndex.getToIndex().isUnique()) {
+        foundIndex = index;
+        break;
+      }
+    }
+
+    if (foundIndex != null) {
+      writeStatements(sqlDialect.indexDropStatements(currentSchema.getTable(changeIndex.getTableName()), changeIndex.getFromIndex()));
+      writeStatements(sqlDialect.renameIndexStatements(currentSchema.getTable(changeIndex.getTableName()), foundIndex.getName(), changeIndex.getToIndex().getName()));
+    } else {
+      writeStatements(sqlDialect.indexDropStatements(currentSchema.getTable(changeIndex.getTableName()), changeIndex.getFromIndex()));
+      writeStatements(sqlDialect.addIndexStatements(currentSchema.getTable(changeIndex.getTableName()), changeIndex.getToIndex()));
+    }
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestGraphBasedUpgradeSchemaChangeVisitor.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestGraphBasedUpgradeSchemaChangeVisitor.java
@@ -273,6 +273,7 @@ public class TestGraphBasedUpgradeSchemaChangeVisitor {
     visitor.startStep(U1.class);
     ChangeIndex changeIndex = mock(ChangeIndex.class);
     when(changeIndex.apply(sourceSchema)).thenReturn(sourceSchema);
+    when(changeIndex.getTableName()).thenReturn("TABLE");
     when(sqlDialect.indexDropStatements(nullable(Table.class), nullable(Index.class))).thenReturn(STATEMENTS);
     when(sqlDialect.addIndexStatements(nullable(Table.class), nullable(Index.class))).thenReturn(STATEMENTS);
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestInlineTableUpgrader.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestInlineTableUpgrader.java
@@ -364,9 +364,20 @@ public class TestInlineTableUpgrader {
     Index index1 = mock(Index.class);
     when(index1.getName()).thenReturn(ID_TABLE_NAME + "_1");
     when(index1.columnNames()).thenReturn(Collections.singletonList("column_0"));
+    when(index1.isUnique()).thenReturn(false);
     Index index2 = mock(Index.class);
-    when(index2.getName()).thenReturn(ID_TABLE_NAME + "_1");
-    when(index2.columnNames()).thenReturn(Collections.singletonList("column_1"));
+    when(index2.getName()).thenReturn(ID_TABLE_NAME + "_2");
+    when(index2.columnNames()).thenReturn(Collections.singletonList("column_2"));
+    when(index2.isUnique()).thenReturn(true);
+
+    Index indexTo1 = mock(Index.class);
+    when(indexTo1.getName()).thenReturn(ID_TABLE_NAME + "_1");
+    when(indexTo1.columnNames()).thenReturn(Collections.singletonList("column_1"));
+    when(indexTo1.isUnique()).thenReturn(false);
+    Index indexTo2 = mock(Index.class);
+    when(indexTo2.getName()).thenReturn(ID_TABLE_NAME + "_2");
+    when(indexTo2.columnNames()).thenReturn(Collections.singletonList("column_2"));
+    when(indexTo2.isUnique()).thenReturn(true);
 
     Index indexPrf = mock(Index.class);
     when(indexPrf.getName()).thenReturn(ID_TABLE_NAME + "_PRF1");
@@ -379,20 +390,30 @@ public class TestInlineTableUpgrader {
 
     ChangeIndex changeIndex = mock(ChangeIndex.class);
     when(changeIndex.getFromIndex()).thenReturn(index1);
-    when(changeIndex.getToIndex()).thenReturn(index2);
+    when(changeIndex.getToIndex()).thenReturn(indexTo1);
     when(changeIndex.getTableName()).thenReturn(ID_TABLE_NAME);
     given(changeIndex.apply(schema)).willReturn(schema);
+
+    ChangeIndex changeIndex1 = mock(ChangeIndex.class);
+    when(changeIndex1.getFromIndex()).thenReturn(index2);
+    when(changeIndex1.getToIndex()).thenReturn(indexTo2);
+    when(changeIndex1.getTableName()).thenReturn(ID_TABLE_NAME);
+    given(changeIndex1.apply(schema)).willReturn(schema);
 
     upgradeConfigAndContext.setIgnoredIndexes(Map.of(ID_TABLE_NAME, List.of(indexPrf, indexPrf1)));
 
     // when
     upgrader.visit(changeIndex);
+    upgrader.visit(changeIndex1);
 
     // then
     verify(changeIndex).apply(schema);
+    verify(changeIndex1).apply(schema);
     verify(sqlDialect).indexDropStatements(nullable(Table.class), eq(index1));
+    verify(sqlDialect).indexDropStatements(nullable(Table.class), eq(index2));
     verify(sqlDialect).renameIndexStatements(nullable(Table.class), eq(ID_TABLE_NAME + "_PRF1"), eq(ID_TABLE_NAME + "_1"));
-    verify(sqlStatementWriter, times(2)).writeSql(anyCollection()); // index drop and index deployment
+    verify(sqlDialect).renameIndexStatements(nullable(Table.class), eq(ID_TABLE_NAME + "_PRF2"), eq(ID_TABLE_NAME + "_2"));
+    verify(sqlStatementWriter, times(4)).writeSql(anyCollection()); // index drop and index deployment
   }
 
 

--- a/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestInlineTableUpgrader.java
+++ b/morf-core/src/test/java/org/alfasoftware/morf/upgrade/TestInlineTableUpgrader.java
@@ -342,6 +342,7 @@ public class TestInlineTableUpgrader {
     // given
     ChangeIndex changeIndex = mock(ChangeIndex.class);
     given(changeIndex.apply(schema)).willReturn(schema);
+    when(changeIndex.getTableName()).thenReturn(ID_TABLE_NAME);
 
     // when
     upgrader.visit(changeIndex);
@@ -350,6 +351,47 @@ public class TestInlineTableUpgrader {
     verify(changeIndex).apply(schema);
     verify(sqlDialect).indexDropStatements(nullable(Table.class), nullable(Index.class));
     verify(sqlDialect).addIndexStatements(nullable(Table.class), nullable(Index.class));
+    verify(sqlStatementWriter, times(2)).writeSql(anyCollection()); // index drop and index deployment
+  }
+
+
+  /**
+   * Test method for {@link org.alfasoftware.morf.upgrade.InlineTableUpgrader#visit(org.alfasoftware.morf.upgrade.ChangeIndex)}.
+   */
+  @Test
+  public void testVisitChangeIndexWithPRFIndex() {
+    // given
+    Index index1 = mock(Index.class);
+    when(index1.getName()).thenReturn(ID_TABLE_NAME + "_1");
+    when(index1.columnNames()).thenReturn(Collections.singletonList("column_0"));
+    Index index2 = mock(Index.class);
+    when(index2.getName()).thenReturn(ID_TABLE_NAME + "_1");
+    when(index2.columnNames()).thenReturn(Collections.singletonList("column_1"));
+
+    Index indexPrf = mock(Index.class);
+    when(indexPrf.getName()).thenReturn(ID_TABLE_NAME + "_PRF1");
+    when(indexPrf.columnNames()).thenReturn(Collections.singletonList("column_1"));
+    when(indexPrf.isUnique()).thenReturn(false);
+    Index indexPrf1 = mock(Index.class);
+    when(indexPrf1.getName()).thenReturn(ID_TABLE_NAME + "_PRF2");
+    when(indexPrf1.columnNames()).thenReturn(List.of("column_2"));
+    when(indexPrf1.isUnique()).thenReturn(true);
+
+    ChangeIndex changeIndex = mock(ChangeIndex.class);
+    when(changeIndex.getFromIndex()).thenReturn(index1);
+    when(changeIndex.getToIndex()).thenReturn(index2);
+    when(changeIndex.getTableName()).thenReturn(ID_TABLE_NAME);
+    given(changeIndex.apply(schema)).willReturn(schema);
+
+    upgradeConfigAndContext.setIgnoredIndexes(Map.of(ID_TABLE_NAME, List.of(indexPrf, indexPrf1)));
+
+    // when
+    upgrader.visit(changeIndex);
+
+    // then
+    verify(changeIndex).apply(schema);
+    verify(sqlDialect).indexDropStatements(nullable(Table.class), eq(index1));
+    verify(sqlDialect).renameIndexStatements(nullable(Table.class), eq(ID_TABLE_NAME + "_PRF1"), eq(ID_TABLE_NAME + "_1"));
     verify(sqlStatementWriter, times(2)).writeSql(anyCollection()); // index drop and index deployment
   }
 

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestDatabaseUpgradeIntegration.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/TestDatabaseUpgradeIntegration.java
@@ -586,7 +586,7 @@ public class TestDatabaseUpgradeIntegration {
       .indexes(
         index("WrongIndexName_1").columns("bigIntegerCol"),
         index("BasicTableWithIndex_1").columns("decimalTenZeroCol"),
-        index("BasicTableWithIndex_2").columns("decimalNineFiveCol"));
+        index("BasicTableWithIndex_2").columns("decimalNineFiveCol").unique());
 
     Schema reAdded = replaceTablesInSchema(tableWithNewAddIndex);
 
@@ -1398,7 +1398,7 @@ public class TestDatabaseUpgradeIntegration {
         () -> verifyUpgrade(expected, List.of(UpdateId.class, DropPrimaryKey.class, UpdateMissingField.class, AddColumn.class, UpdateField.class)));
 
     assertThat(exception.getMessage(), containsString("Error executing SQL"));
-    assertThat(exception.getMessage(), containsString("UPDATE WithDefaultValue SET missingColumn"));
+    assertThat(exception.getMessage().replace(connectionResources.getSchemaName() + ".", ""), containsString("UPDATE WithDefaultValue SET missingColumn"));
   }
 
 

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/testdatabaseupgradeintegration/upgrade/v1_0_0/AddIndex.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/integration/testdatabaseupgradeintegration/upgrade/v1_0_0/AddIndex.java
@@ -13,6 +13,6 @@ public class AddIndex extends AbstractTestUpgradeStep {
   @Override
   public void execute(SchemaEditor schema, DataEditor data) {
     schema.addIndex("BasicTableWithIndex", index("BasicTableWithIndex_1").columns("decimalTenZeroCol"));
-    schema.addIndex("BasicTableWithIndex", index("BasicTableWithIndex_2").columns("decimalNineFiveCol"));
+    schema.addIndex("BasicTableWithIndex", index("BasicTableWithIndex_2").columns("decimalNineFiveCol").unique());
   }
 }

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
@@ -33,7 +33,9 @@ import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.equalToIgnoringCase;
 import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -56,6 +58,7 @@ import org.alfasoftware.morf.sql.SelectStatement;
 import org.alfasoftware.morf.testing.DatabaseSchemaManager;
 import org.alfasoftware.morf.testing.DatabaseSchemaManager.TruncationBehavior;
 import org.alfasoftware.morf.testing.TestingDataSourceModule;
+import org.alfasoftware.morf.upgrade.LoggingSqlScriptVisitor;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -87,6 +90,8 @@ public class TestDatabaseMetaDataProvider {
   @Inject
   private ConnectionResources database;
 
+  @Inject
+  private SqlScriptExecutorProvider sqlScriptExecutorProvider;
 
   private final Schema schema = schema(
     schema(
@@ -282,11 +287,89 @@ public class TestDatabaseMetaDataProvider {
         indexMatcher(
           index("NaturalKey").columns("decimalElevenCol").unique()))
       ));
+    }
 
-      schemaResource.getAdditionalMetadata().ifPresent(additionalMetadata ->
-        assertThat(additionalMetadata.ignoredIndexes().get("WithTypes".toLowerCase()), containsInAnyOrder(ImmutableList.of(
-          indexMatcher(index("WithTypes_PRF1").columns("decimalNineFiveCol", "bigIntegerCol"))
-      ))));
+    SqlScriptExecutor sqlExecutor;
+
+    switch (database.sqlDialect().getDatabaseType().identifier()) {
+      case "PGSQL":
+        sqlExecutor = sqlScriptExecutorProvider.get(new LoggingSqlScriptVisitor());
+        sqlExecutor.execute("CREATE INDEX WithTypes_PRF2 ON " + database.getSchemaName() + ".WithTypes (LENGTH(primaryStringCol))");
+
+        // open schema resource again to re-read index definitions
+        try (SchemaResource schemaResource = database.openSchemaResource()) {
+          schemaResource.getAdditionalMetadata().ifPresent(additionalMetadata ->
+              assertThat(additionalMetadata.ignoredIndexes().get("WithTypes".toLowerCase()), containsInAnyOrder(ImmutableList.of(
+                  indexMatcher(index("WithTypes_PRF1").columns("decimalNineFiveCol", "bigIntegerCol"))
+              ))));
+        }
+        break;
+      case "ORACLE":
+        sqlExecutor = sqlScriptExecutorProvider.get(new LoggingSqlScriptVisitor());
+        sqlExecutor.execute("CREATE INDEX WithTypes_PRF2 ON " + database.getSchemaName() + ".WithTypes (LENGTH(primaryStringCol))");
+
+        // open schema resource again to re-read index definitions
+        try (SchemaResource schemaResource = database.openSchemaResource()) {
+          schemaResource.getAdditionalMetadata().ifPresent(additionalMetadata ->
+              assertThat(additionalMetadata.ignoredIndexes().get("WithTypes".toUpperCase()), containsInAnyOrder(ImmutableList.of(
+                  indexMatcher(index("WithTypes_PRF1").columns("decimalNineFiveCol", "bigIntegerCol"))
+              ))));
+        }
+        break;
+      default:
+        break;
+    }
+  }
+
+
+  /**
+   * Validates that the openSchemaResources throws an exception when an invalid expression index that is not a
+   * performance index exists on a table.
+   */
+  @Test
+  public void testTableWithTypesWithInvalidExpressionIndexThrowsException() {
+    try(SchemaResource schemaResource = database.openSchemaResource()) {
+      assertTrue(schemaResource.tableExists("WithTypes"));
+      Table table = schemaResource.getTable("WithTypes");
+
+      assertThat(table.isTemporary(), is(false));
+      assertThat(table.getName(), tableNameEqualTo("WithTypes"));
+
+      assertThat(table.primaryKey(), contains(ImmutableList.of(
+          columnMatcher(
+              column("primaryStringCol", DataType.STRING, 15).primaryKey()),
+          columnMatcher(
+              column("primaryBigIntegerCol", DataType.BIG_INTEGER).primaryKey()))
+      ));
+
+      assertThat(table.indexes(), containsInAnyOrder(ImmutableList.of(
+          indexMatcher(
+              index("WithTypes_1").columns("booleanCol", "dateCol")),
+          indexMatcher(
+              index("NaturalKey").columns("decimalElevenCol").unique()))
+      ));
+    }
+
+    SqlScriptExecutor sqlExecutor;
+
+    switch(database.sqlDialect().getDatabaseType().identifier()) {
+      case "PGSQL":
+      case "ORACLE":
+        sqlExecutor = sqlScriptExecutorProvider.get(new LoggingSqlScriptVisitor());
+        sqlExecutor.execute("CREATE INDEX WithTypes_2 ON " + database.getSchemaName() + ".WithTypes (LENGTH(primaryStringCol))");
+
+        // open schema resource again to re-read index definitions and throw exception due to invalid index
+        assertThrows(IllegalArgumentException.class, () -> {
+          try (SchemaResource schemaResource = database.openSchemaResource()) {
+            schemaResource.getAdditionalMetadata().ifPresent(additionalMetadata ->
+                assertEquals(0, additionalMetadata.ignoredIndexes().size()));
+          }
+        });
+
+        sqlExecutor.execute("DROP INDEX WithTypes_2");
+        break;
+      default:
+        break;
     }
   }
 

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
@@ -544,15 +544,17 @@ public class TestDatabaseMetaDataProvider {
   @Test
   public void testDatabaseInformation() {
     try (Connection connection = this.database.getDataSource().getConnection()) {
-      Schema schema = DatabaseType.Registry.findByIdentifier(database.getDatabaseType()).openSchema(connection, database.getDatabaseName(), database.getSchemaName());
+      if (this.database.getDatabaseType().equals("PGSQL")) {
+        Schema schema = DatabaseType.Registry.findByIdentifier(database.getDatabaseType()).openSchema(connection, database.getDatabaseName(), database.getSchemaName());
 
-      Map<String, String> databaseInformation = ((DatabaseMetaDataProvider) schema).getDatabaseInformation();
-      assertTrue(databaseInformation.containsKey(DATABASE_PRODUCT_VERSION));
-      assertTrue(databaseInformation.containsKey(DATABASE_MAJOR_VERSION));
-      assertTrue(databaseInformation.containsKey(DATABASE_MINOR_VERSION));
+        Map<String, String> databaseInformation = ((DatabaseMetaDataProvider) schema).getDatabaseInformation();
+        assertTrue(databaseInformation.containsKey(DATABASE_PRODUCT_VERSION));
+        assertTrue(databaseInformation.containsKey(DATABASE_MAJOR_VERSION));
+        assertTrue(databaseInformation.containsKey(DATABASE_MINOR_VERSION));
+      }
     }
     catch (RuntimeException | SQLException e) {
-      assertThat(e.getMessage(), equalToIgnoringCase("Exception copying table [WITHTIMESTAMP]"));
+      assertThat(e.getMessage(), equalToIgnoringCase("Exception reading database information"));
     }
   }
 

--- a/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
+++ b/morf-integration-test/src/test/java/org/alfasoftware/morf/jdbc/TestDatabaseMetaDataProvider.java
@@ -16,6 +16,9 @@
 package org.alfasoftware.morf.jdbc;
 
 import static java.util.stream.Collectors.toList;
+import static org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider.DATABASE_MAJOR_VERSION;
+import static org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider.DATABASE_MINOR_VERSION;
+import static org.alfasoftware.morf.jdbc.DatabaseMetaDataProvider.DATABASE_PRODUCT_VERSION;
 import static org.alfasoftware.morf.metadata.SchemaUtils.column;
 import static org.alfasoftware.morf.metadata.SchemaUtils.index;
 import static org.alfasoftware.morf.metadata.SchemaUtils.schema;
@@ -42,6 +45,7 @@ import static org.junit.Assert.fail;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.List;
+import java.util.Map;
 import java.util.function.Function;
 
 import org.alfasoftware.morf.guicesupport.InjectMembersRule;
@@ -59,6 +63,9 @@ import org.alfasoftware.morf.testing.DatabaseSchemaManager;
 import org.alfasoftware.morf.testing.DatabaseSchemaManager.TruncationBehavior;
 import org.alfasoftware.morf.testing.TestingDataSourceModule;
 import org.alfasoftware.morf.upgrade.LoggingSqlScriptVisitor;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.log4j.Level;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
 import org.hamcrest.Matchers;
@@ -155,6 +162,10 @@ public class TestDatabaseMetaDataProvider {
 
   @Before
   public void before() throws SQLException {
+    Log log =  LogFactory.getLog(DatabaseMetaDataProvider.class);
+    if (log instanceof org.apache.commons.logging.impl.Log4JLogger) {
+      ((org.apache.commons.logging.impl.Log4JLogger)log).getLogger().setLevel(Level.DEBUG);
+    }
 
     databaseType = database.getDatabaseType();
 
@@ -298,10 +309,12 @@ public class TestDatabaseMetaDataProvider {
 
         // open schema resource again to re-read index definitions
         try (SchemaResource schemaResource = database.openSchemaResource()) {
-          schemaResource.getAdditionalMetadata().ifPresent(additionalMetadata ->
+          schemaResource.getAdditionalMetadata().ifPresent(additionalMetadata -> {
+              assertFalse("repeat read of ignored indexes for coverage", additionalMetadata.ignoredIndexes().isEmpty());
               assertThat(additionalMetadata.ignoredIndexes().get("WithTypes".toLowerCase()), containsInAnyOrder(ImmutableList.of(
                   indexMatcher(index("WithTypes_PRF1").columns("decimalNineFiveCol", "bigIntegerCol"))
-              ))));
+              )));
+        });
         }
         break;
       case "ORACLE":
@@ -310,10 +323,12 @@ public class TestDatabaseMetaDataProvider {
 
         // open schema resource again to re-read index definitions
         try (SchemaResource schemaResource = database.openSchemaResource()) {
-          schemaResource.getAdditionalMetadata().ifPresent(additionalMetadata ->
-              assertThat(additionalMetadata.ignoredIndexes().get("WithTypes".toUpperCase()), containsInAnyOrder(ImmutableList.of(
-                  indexMatcher(index("WithTypes_PRF1").columns("decimalNineFiveCol", "bigIntegerCol"))
-              ))));
+          schemaResource.getAdditionalMetadata().ifPresent(additionalMetadata -> {
+            assertFalse("repeat read of ignored indexes for coverage", additionalMetadata.ignoredIndexes().isEmpty());
+            assertThat(additionalMetadata.ignoredIndexes().get("WithTypes".toUpperCase()), containsInAnyOrder(ImmutableList.of(
+                indexMatcher(index("WithTypes_PRF1").columns("decimalNineFiveCol", "bigIntegerCol"))
+            )));
+          });
         }
         break;
       default:
@@ -522,6 +537,35 @@ public class TestDatabaseMetaDataProvider {
     }
     catch (RuntimeException e) {
       assertThat(e.getMessage(), equalToIgnoringCase("Exception copying table [WITHTIMESTAMP]"));
+    }
+  }
+
+
+  @Test
+  public void testDatabaseInformation() {
+    try (Connection connection = this.database.getDataSource().getConnection()) {
+      Schema schema = DatabaseType.Registry.findByIdentifier(database.getDatabaseType()).openSchema(connection, database.getDatabaseName(), database.getSchemaName());
+
+      Map<String, String> databaseInformation = ((DatabaseMetaDataProvider) schema).getDatabaseInformation();
+      assertTrue(databaseInformation.containsKey(DATABASE_PRODUCT_VERSION));
+      assertTrue(databaseInformation.containsKey(DATABASE_MAJOR_VERSION));
+      assertTrue(databaseInformation.containsKey(DATABASE_MINOR_VERSION));
+    }
+    catch (RuntimeException | SQLException e) {
+      assertThat(e.getMessage(), equalToIgnoringCase("Exception copying table [WITHTIMESTAMP]"));
+    }
+  }
+
+
+  @Test
+  public void testSequenceExists() {
+    try (Connection connection = this.database.getDataSource().getConnection()) {
+      Schema schema = DatabaseType.Registry.findByIdentifier(database.getDatabaseType()).openSchema(connection, database.getDatabaseName(), database.getSchemaName());
+
+      assertFalse(schema.sequenceExists("NonExisting_SEQ"));
+    }
+    catch (RuntimeException | SQLException e) {
+      assertThat(e.getMessage(), equalToIgnoringCase("Exception with sequence exists."));
     }
   }
 

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleMetaDataProvider.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleMetaDataProvider.java
@@ -204,9 +204,6 @@ public class OracleMetaDataProvider implements AdditionalMetadata {
           String columnComment = resultSet.getString(4);
           String dataTypeName = resultSet.getString(5);
 
-          if (isSystemTable(tableName))
-            continue;
-
           try {
             Integer dataLength;
             if (dataTypeName.contains("CHAR")) {

--- a/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleMetaDataProvider.java
+++ b/morf-oracle/src/main/java/org/alfasoftware/morf/jdbc/oracle/OracleMetaDataProvider.java
@@ -488,6 +488,11 @@ public class OracleMetaDataProvider implements AdditionalMetadata {
 
             lastIndex.columnNames().add(columnName);
 
+            if (StringUtils.isEmpty(columnName)) {
+              // remove invalid index has it has an expression
+              ignoredIndexes.get(currentTable.getName().toUpperCase()).remove(lastIndex);
+            }
+
             continue;
           }
 
@@ -506,19 +511,23 @@ public class OracleMetaDataProvider implements AdditionalMetadata {
 
           // Correct the case on the column name
           columnName = getColumnCorrectCase(currentTable, columnName);
+          if (StringUtils.isEmpty(columnName)) {
+            throw new IllegalArgumentException("Found a column that is an expression in an index.");
+          }
 
           lastIndex.columnNames().add(columnName);
         }
       }
 
       private String getColumnCorrectCase(Table currentTable, String columnName) {
+        String columnNameFound = "";
         for (Column currentColumn : currentTable.columns()) {
           if (currentColumn.getName().equalsIgnoreCase(columnName)) {
-            columnName = currentColumn.getName();
+            columnNameFound = currentColumn.getName();
             break;
           }
         }
-        return columnName;
+        return columnNameFound;
       }
     });
 

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleMetaDataProvider.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleMetaDataProvider.java
@@ -17,6 +17,7 @@ package org.alfasoftware.morf.jdbc.oracle;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -46,6 +47,7 @@ import org.alfasoftware.morf.metadata.DataType;
 import org.alfasoftware.morf.metadata.Index;
 import org.alfasoftware.morf.metadata.Schema;
 import org.alfasoftware.morf.metadata.Sequence;
+import org.alfasoftware.morf.metadata.Table;
 import org.alfasoftware.morf.metadata.View;
 import org.alfasoftware.morf.sql.SelectStatement;
 import org.junit.Before;
@@ -151,6 +153,7 @@ public class TestOracleMetaDataProvider {
     expectedPrimaryKeyIndexNames.put("AREALTABLE", "AREALTABLE_PK");
     expectedPrimaryKeyIndexNames.put("AREALTABLE2", "AREALTABLE2_PK");
     assertEquals("Primary key index names.", expectedPrimaryKeyIndexNames, oracleMetaDataProvider.primaryKeyIndexNames());
+    assertEquals("Repeat for coverage - Primary key index names.", expectedPrimaryKeyIndexNames, oracleMetaDataProvider.primaryKeyIndexNames());
   }
 
   /**
@@ -171,11 +174,14 @@ public class TestOracleMetaDataProvider {
 
       //
       when(resultSet.getString(1)).thenReturn("AREALTABLE", "AREALTABLE", "AREALTABLE", "AREALTABLE");
-      when(resultSet.getString(2)).thenReturn("TableComment", "TableComment", "TableComment", "TableComment");
+      when(resultSet.getString(2)).thenReturn("REALNAME:[ArealTable]", "REALNAME:[ArealTable]", "REALNAME:[ArealTable]", "REALNAME:[ArealTable]");
       when(resultSet.getString(3)).thenReturn("ID", "column1", "column2", "column3");
-      when(resultSet.getString(4)).thenReturn("IDComment", "column1Comment", "column2Comment", "column3Comment");
-      when(resultSet.getString(5)).thenReturn("VARCHAR2", "VARCHAR2", "VARCHAR2", "VARCHAR2");
+      when(resultSet.getString(4)).thenReturn("REALNAME:[ID]/TYPE:[STRING]/AUTONUMSTART:[3]", "REALNAME:[column1]/TYPE:[DECIMAL]",
+          "REALNAME:[column2]/TYPE:[STRING]", "REALNAME:[column3]/TYPE:[STRING]");
+      when(resultSet.getString(5)).thenReturn("VARCHAR2", "DECIMAL", "VARCHAR2", "VARCHAR2");
       when(resultSet.getString(6)).thenReturn("10", "11", "12", "13");
+      when(resultSet.getInt(8)).thenReturn(0, 13, 0, 0); // precision
+      when(resultSet.getInt(9)).thenReturn(0, 2, 0, 0); // scale
       return resultSet;
     }).thenAnswer(new ReturnTablesMockResultSet(4));
 
@@ -185,11 +191,11 @@ public class TestOracleMetaDataProvider {
     // two indexes, one of which is an ignored index
     when(statement1.executeQuery()).thenAnswer(answer -> {
       ResultSet resultSet = mock(ResultSet.class, RETURNS_SMART_NULLS);
-      when(resultSet.next()).thenReturn(true, true, true, false);
+      when(resultSet.next()).thenReturn(true, true, true, true, false);
       when(resultSet.getString(1)).thenReturn("AREALTABLE", "AREALTABLE", "AREALTABLE");
-      when(resultSet.getString(2)).thenReturn("AREALTABLE_1", "AREALTABLE_PRF1", "AREALTABLE_PRF2");
-      when(resultSet.getString(3)).thenReturn("", "", "UNIQUE");
-      when(resultSet.getString(4)).thenReturn("VALID", "VALID");
+      when(resultSet.getString(2)).thenReturn("AREALTABLE_1", "AREALTABLE_PRF1", "AREALTABLE_PRF2", "AREALTABLE_PRF3");
+      when(resultSet.getString(3)).thenReturn("", "", "UNIQUE", "");
+      when(resultSet.getString(4)).thenReturn("VALID", "VALID", "VALID", "VALID");
       return resultSet;
     });
 
@@ -197,13 +203,13 @@ public class TestOracleMetaDataProvider {
     PreparedStatement statement2 = mock(PreparedStatement.class, RETURNS_SMART_NULLS);
     when(connection.prepareStatement("select table_name, INDEX_NAME, COLUMN_NAME from ALL_IND_COLUMNS where INDEX_OWNER=? order by table_name, index_name, column_position")).thenReturn(statement2);
 
-    // two indexes, one of which is an ignored index
+    // four indexes, three of which is an ignored index. The last one is an index with a function expression
     when(statement2.executeQuery()).thenAnswer(answer -> {
       ResultSet resultSet = mock(ResultSet.class, RETURNS_SMART_NULLS);
-      when(resultSet.next()).thenReturn(true, true, true, false);
-      when(resultSet.getString(1)).thenReturn("AREALTABLE", "AREALTABLE", "AREALTABLE");
-      when(resultSet.getString(2)).thenReturn("AREALTABLE_1", "AREALTABLE_PRF1", "AREALTABLE_PRF2");
-      when(resultSet.getString(3)).thenReturn("column1", "column2", "column3");
+      when(resultSet.next()).thenReturn(true, true, true, true, false);
+      when(resultSet.getString(1)).thenReturn("AREALTABLE", "AREALTABLE", "AREALTABLE", "AREALTABLE");
+      when(resultSet.getString(2)).thenReturn("AREALTABLE_1", "AREALTABLE_PRF1", "AREALTABLE_PRF2", "AREALTABLE_PRF3");
+      when(resultSet.getString(3)).thenReturn("column1", "column2", "column3", "length(column1)");
       return resultSet;
     });
 
@@ -215,16 +221,82 @@ public class TestOracleMetaDataProvider {
     assertEquals("Ignored indexes size.", 2, actualIgnoredIndexes.size());
     assertEquals("Ignored AREALTABLE table indexes size.", 2, actualIgnoredIndexes.size());
     Index index = actualIgnoredIndexes.get(0);
-    assertEquals("Ignored index name.", "AREALTABLE_PRF1", index.getName());
+    assertEquals("Ignored index name.", "ArealTable_PRF1", index.getName());
     assertEquals("Ignored index column.", "column2", index.columnNames().get(0));
     assertFalse("Ignored index uniqueness.", index.isUnique());
-    assertEquals("Index-AREALTABLE_PRF1--column2", index.toStringHelper());
+    assertEquals("Index-ArealTable_PRF1--column2", index.toStringHelper());
 
     Index index2 = actualIgnoredIndexes.get(1);
-    assertEquals("Ignored index name.", "AREALTABLE_PRF2", index2.getName());
+    assertEquals("Ignored index name.", "ArealTable_PRF2", index2.getName());
     assertEquals("Ignored index column.", "column3", index2.columnNames().get(0));
     assertTrue("Ignored index uniqueness.", index2.isUnique());
-    assertEquals("Index-AREALTABLE_PRF2-unique-column3", index2.toStringHelper());
+    assertEquals("Index-ArealTable_PRF2-unique-column3", index2.toStringHelper());
+
+    assertEquals("Only two prf indexes", 2, actualIgnoredIndexes.size());
+  }
+
+  /**
+   * Checks the building of the collection of primary key index names.
+   * @throws SQLException
+   */
+  @Test
+  public void testDifferentColumnDefaultValues() throws SQLException {
+    // Given
+    final PreparedStatement statement = mock(PreparedStatement.class, RETURNS_SMART_NULLS);
+    when(connection.prepareStatement(anyString())).thenReturn(statement);
+
+    mockGetTableKeysQuery(0, false, false);
+    // This is the table that's returned.
+    when(statement.executeQuery()).thenAnswer(invocation -> {
+      final ResultSet resultSet = mock(ResultSet.class, RETURNS_SMART_NULLS);
+      when(resultSet.next()).thenReturn(true, true, true, true, false);
+
+      //
+      when(resultSet.getString(1)).thenReturn("AREALTABLE", "AREALTABLE", "AREALTABLE", "AREALTABLE");
+      when(resultSet.getString(2)).thenReturn("REALNAME:[ArealTable]", "REALNAME:[ArealTable]", "REALNAME:[ArealTable]", "REALNAME:[ArealTable]");
+      when(resultSet.getString(3)).thenReturn("ID", "column1", "column2", "column3");
+      when(resultSet.getString(4)).thenReturn("REALNAME:[ID]/TYPE:[STRING]/AUTONUMSTART:[3]", "REALNAME:[column1]/TYPE:[DECIMAL]", "REALNAME:[column2]/TYPE:[STRING]", "REALNAME:[column3]/TYPE:[STRING]");
+      when(resultSet.getString(5)).thenReturn("VARCHAR2", "DECIMAL", "VARCHAR2", "VARCHAR2");
+      when(resultSet.getString(6)).thenReturn("10", "11", "12", "13");
+      when(resultSet.getInt(8)).thenReturn(0, 13, 0, 0); // precision
+      when(resultSet.getInt(9)).thenReturn(0, 2, 0, 0); // scale
+      when(resultSet.getString(11)).thenReturn("'10'", "'11'", "'12'", "'13'");
+      return resultSet;
+    }).thenAnswer(new ReturnTablesMockResultSet(4));
+
+    PreparedStatement statement1 = mock(PreparedStatement.class, RETURNS_SMART_NULLS);
+    when(connection.prepareStatement("select table_name, index_name, uniqueness, status from ALL_INDEXES where owner=? order by table_name, index_name")).thenReturn(statement1);
+
+    // one index
+    when(statement1.executeQuery()).thenAnswer(answer -> {
+      ResultSet resultSet = mock(ResultSet.class, RETURNS_SMART_NULLS);
+      when(resultSet.next()).thenReturn(true, false);
+      when(resultSet.getString(1)).thenReturn("AREALTABLE");
+      when(resultSet.getString(2)).thenReturn("AREALTABLE_1");
+      when(resultSet.getString(3)).thenReturn("");
+      when(resultSet.getString(4)).thenReturn("VALID");
+      return resultSet;
+    });
+
+    // "select table_name, INDEX_NAME, COLUMN_NAME from ALL_IND_COLUMNS where INDEX_OWNER=? order by table_name, index_name, column_position"
+    PreparedStatement statement2 = mock(PreparedStatement.class, RETURNS_SMART_NULLS);
+    when(connection.prepareStatement("select table_name, INDEX_NAME, COLUMN_NAME from ALL_IND_COLUMNS where INDEX_OWNER=? order by table_name, index_name, column_position")).thenReturn(statement2);
+
+    // two indexes, one of which is an ignored index
+    when(statement2.executeQuery()).thenAnswer(answer -> {
+      ResultSet resultSet = mock(ResultSet.class, RETURNS_SMART_NULLS);
+      when(resultSet.next()).thenReturn(true, false);
+      when(resultSet.getString(1)).thenReturn("AREALTABLE");
+      when(resultSet.getString(2)).thenReturn("AREALTABLE_1");
+      when(resultSet.getString(3)).thenReturn("column1");
+      return resultSet;
+    });
+
+    // When
+    final AdditionalMetadata oracleMetaDataProvider = (AdditionalMetadata) oracle.openSchema(connection, "TESTDATABASE", "TESTSCHEMA");
+    Table table = oracleMetaDataProvider.getTable("AREALTABLE");
+
+    assertNotNull("Table null", table);
   }
 
   @Test

--- a/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleMetaDataProvider.java
+++ b/morf-oracle/src/test/java/org/alfasoftware/morf/jdbc/oracle/TestOracleMetaDataProvider.java
@@ -167,15 +167,15 @@ public class TestOracleMetaDataProvider {
     // This is the table that's returned.
     when(statement.executeQuery()).thenAnswer(invocation -> {
       final ResultSet resultSet = mock(ResultSet.class, RETURNS_SMART_NULLS);
-      when(resultSet.next()).thenReturn(true, false);
+      when(resultSet.next()).thenReturn(true, true, true, true, false);
 
       //
-      when(resultSet.getString(1)).thenReturn("AREALTABLE");
-      when(resultSet.getString(2)).thenReturn("TableComment");
-      when(resultSet.getString(3)).thenReturn("ID");
-      when(resultSet.getString(4)).thenReturn("IDComment");
-      when(resultSet.getString(5)).thenReturn("VARCHAR2");
-      when(resultSet.getString(6)).thenReturn("10");
+      when(resultSet.getString(1)).thenReturn("AREALTABLE", "AREALTABLE", "AREALTABLE", "AREALTABLE");
+      when(resultSet.getString(2)).thenReturn("TableComment", "TableComment", "TableComment", "TableComment");
+      when(resultSet.getString(3)).thenReturn("ID", "column1", "column2", "column3");
+      when(resultSet.getString(4)).thenReturn("IDComment", "column1Comment", "column2Comment", "column3Comment");
+      when(resultSet.getString(5)).thenReturn("VARCHAR2", "VARCHAR2", "VARCHAR2", "VARCHAR2");
+      when(resultSet.getString(6)).thenReturn("10", "11", "12", "13");
       return resultSet;
     }).thenAnswer(new ReturnTablesMockResultSet(4));
 


### PR DESCRIPTION
Add tolerance for expression indexes when PRF.
Add throw when database schema has an expression index that is not a PRF index. Update tests for integration and unit test coverage.